### PR TITLE
feat(docs): Complete OpenAPI 3.0 spec for all 41 API endpoints

### DIFF
--- a/src/lib/openapi/agents.ts
+++ b/src/lib/openapi/agents.ts
@@ -1,0 +1,886 @@
+export const agentPaths = {
+  '/agents': {
+    get: {
+      operationId: 'listAgents',
+      summary: 'List agents',
+      description:
+        'Retrieve a paginated list of agents for the current tenant. Supports filtering by status, role, and free-text search.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'status',
+          in: 'query',
+          required: false,
+          description: 'Filter agents by lifecycle status.',
+          schema: {
+            type: 'string',
+            enum: [
+              'initializing',
+              'idle',
+              'active',
+              'paused',
+              'blocked',
+              'error',
+              'escaped',
+              'terminated',
+            ],
+          },
+        },
+        {
+          name: 'role',
+          in: 'query',
+          required: false,
+          description: 'Filter agents by organizational role.',
+          schema: {
+            type: 'string',
+            enum: ['ceo', 'manager', 'worker', 'specialist', 'system'],
+          },
+        },
+        {
+          name: 'search',
+          in: 'query',
+          required: false,
+          description:
+            'Free-text search across agent name, slug, and description.',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          required: false,
+          description: 'Page number for pagination.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            default: 1,
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of agents per page.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 20,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of agents.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Agent',
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                  pagination: {
+                    $ref: '#/components/schemas/Pagination',
+                  },
+                },
+                required: ['data', 'meta', 'pagination'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'createAgent',
+      summary: 'Create agent',
+      description:
+        'Create a new agent within the current tenant. The agent is placed in the hierarchy under the specified parent, or at the root if no parent_id is provided.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/CreateAgentInput',
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Agent created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Agent',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/agents/{id}': {
+    get: {
+      operationId: 'getAgent',
+      summary: 'Get agent',
+      description:
+        'Retrieve a single agent by its unique identifier, including full configuration and hierarchy metadata.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'The requested agent.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Agent',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    patch: {
+      operationId: 'updateAgent',
+      summary: 'Update agent',
+      description:
+        'Partially update an existing agent. Only the fields provided in the request body are modified; all other fields remain unchanged.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent to update.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/UpdateAgentInput',
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Agent updated successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Agent',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    delete: {
+      operationId: 'deleteAgent',
+      summary: 'Delete agent',
+      description:
+        'Permanently delete an agent. Any child agents must be reassigned or deleted before this operation can succeed.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent to delete.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Agent deleted successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The identifier of the deleted agent.',
+                      },
+                      deleted: {
+                        type: 'boolean',
+                        description: 'Always true on successful deletion.',
+                        enum: [true],
+                      },
+                    },
+                    required: ['id', 'deleted'],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/agents/{id}/config': {
+    get: {
+      operationId: 'getAgentConfig',
+      summary: 'Get agent configuration',
+      description:
+        'Retrieve the current active configuration for an agent, including LLM settings, capability limits, and behavioral parameters.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'The current agent configuration.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/AgentConfig',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    patch: {
+      operationId: 'updateAgentConfig',
+      summary: 'Update agent configuration',
+      description:
+        'Partially update the configuration for an agent. A new configuration version is created automatically, preserving the previous version for rollback.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/UpdateAgentConfigInput',
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Agent configuration updated successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/AgentConfig',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/agents/{id}/config/test': {
+    post: {
+      operationId: 'testAgentConfig',
+      summary: 'Test agent configuration',
+      description:
+        'Validate an agent configuration without persisting it. Returns any errors or warnings detected during validation, allowing you to verify changes before applying them.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent whose context is used for validation.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/TestAgentConfigInput',
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Configuration validation result.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      valid: {
+                        type: 'boolean',
+                        description: 'Whether the configuration passed all validation checks.',
+                      },
+                      errors: {
+                        type: 'array',
+                        items: {
+                          type: 'string',
+                        },
+                        description: 'List of validation errors that must be fixed.',
+                      },
+                      warnings: {
+                        type: 'array',
+                        items: {
+                          type: 'string',
+                        },
+                        description: 'List of non-blocking warnings about the configuration.',
+                      },
+                    },
+                    required: ['valid', 'errors', 'warnings'],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/agents/{id}/config/versions': {
+    get: {
+      operationId: 'listConfigVersions',
+      summary: 'List config versions',
+      description:
+        'Retrieve a paginated history of configuration versions for an agent, ordered from most recent to oldest. Each version captures a snapshot of the configuration at the time it was changed.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          required: false,
+          description: 'Page number for pagination.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            default: 1,
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of versions per page.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 20,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of configuration versions.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/ConfigVersion',
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                  pagination: {
+                    $ref: '#/components/schemas/Pagination',
+                  },
+                },
+                required: ['data', 'meta', 'pagination'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/agents/{id}/config/restore': {
+    post: {
+      operationId: 'restoreConfigVersion',
+      summary: 'Restore config version',
+      description:
+        'Restore the agent configuration to a previously saved version. The restored version becomes the new active configuration and a new version entry is created for audit purposes.',
+      tags: ['Agents'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                version_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description: 'The identifier of the configuration version to restore.',
+                },
+              },
+              required: ['version_id'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Configuration restored successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/AgentConfig',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid version_id or version not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/lib/openapi/decisions-escalations.ts
+++ b/src/lib/openapi/decisions-escalations.ts
@@ -1,0 +1,1031 @@
+/**
+ * OpenAPI 3.0 path definitions for Decision and Escalation endpoints.
+ *
+ * Exports `decisionPaths` and `escalationPaths` objects that can be merged
+ * into the top-level `paths` section of an OpenAPI spec.
+ *
+ * Schema references (e.g. Decision, Escalation, ErrorResponse, Pagination)
+ * are expected to live under `#/components/schemas/` in the root spec
+ * (see swagger.ts for definitions).
+ */
+
+// ---------------------------------------------------------------------------
+// Decision Paths
+// ---------------------------------------------------------------------------
+
+export const decisionPaths = {
+  '/decisions': {
+    get: {
+      operationId: 'listDecisions',
+      summary: 'List decisions',
+      description:
+        'Retrieve a paginated list of decisions with optional filtering by agent, status, category, date range, confidence, and full-text search.',
+      tags: ['Decisions'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'agent_id',
+          in: 'query',
+          required: false,
+          description: 'Filter by the agent that proposed the decision.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+        {
+          name: 'status',
+          in: 'query',
+          required: false,
+          description: 'Filter by decision status.',
+          schema: {
+            type: 'string',
+            enum: ['proposed', 'approved', 'rejected', 'overridden', 'executed'],
+          },
+        },
+        {
+          name: 'category',
+          in: 'query',
+          required: false,
+          description: 'Filter by decision category.',
+          schema: {
+            type: 'string',
+            enum: ['action', 'resource', 'escalation', 'strategy', 'system'],
+          },
+        },
+        {
+          name: 'date_from',
+          in: 'query',
+          required: false,
+          description: 'Return decisions proposed on or after this datetime (ISO 8601).',
+          schema: { type: 'string', format: 'date-time' },
+        },
+        {
+          name: 'date_to',
+          in: 'query',
+          required: false,
+          description: 'Return decisions proposed on or before this datetime (ISO 8601).',
+          schema: { type: 'string', format: 'date-time' },
+        },
+        {
+          name: 'confidence_min',
+          in: 'query',
+          required: false,
+          description: 'Minimum reasoning confidence score (0-1).',
+          schema: { type: 'number', minimum: 0, maximum: 1 },
+        },
+        {
+          name: 'search',
+          in: 'query',
+          required: false,
+          description: 'Full-text search across decision title and description.',
+          schema: { type: 'string', minLength: 1, maxLength: 200 },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          required: false,
+          description: 'Page number (1-indexed).',
+          schema: { type: 'integer', minimum: 1, default: 1 },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of results per page.',
+          schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of decisions.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Decision' },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                  pagination: { $ref: '#/components/schemas/Pagination' },
+                },
+                required: ['data', 'meta', 'pagination'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid query parameters.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'createDecision',
+      summary: 'Create decision',
+      description:
+        'Propose a new decision on behalf of an agent. The decision starts in the `proposed` status unless `self_authorized` is true.',
+      tags: ['Decisions'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/CreateDecisionInput' },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Decision created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Decision' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Referenced agent or task not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/decisions/{id}': {
+    get: {
+      operationId: 'getDecision',
+      summary: 'Get decision with history',
+      description:
+        'Retrieve a single decision by ID including expanded agent, task, and overrider relations.',
+      tags: ['Decisions'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Decision UUID.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Decision details with relations.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Decision' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Decision not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+    patch: {
+      operationId: 'updateDecision',
+      summary: 'Update decision status or override',
+      description:
+        'Update the status, outcome, or executed action of a decision. To override a decision, supply `reason` (and optionally `correct_action`) instead of `status`.',
+      tags: ['Decisions'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Decision UUID.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              oneOf: [
+                { $ref: '#/components/schemas/UpdateDecisionInput' },
+                { $ref: '#/components/schemas/OverrideDecisionInput' },
+              ],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Decision updated successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Decision' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error or invalid state transition.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Decision not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/decisions/{id}/context': {
+    get: {
+      operationId: 'getDecisionContext',
+      summary: 'Get decision context',
+      description:
+        'Retrieve the full context surrounding a decision, including related tasks, escalations, and the proposing agent\'s recent decision history.',
+      tags: ['Decisions'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Decision UUID.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Decision context with related entities.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      decision: { $ref: '#/components/schemas/Decision' },
+                      related_tasks: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/Task' },
+                      },
+                      related_escalations: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/Escalation' },
+                      },
+                      agent_history: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/Decision' },
+                      },
+                    },
+                    required: [
+                      'decision',
+                      'related_tasks',
+                      'related_escalations',
+                      'agent_history',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Decision not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/decisions/stats': {
+    get: {
+      operationId: 'getDecisionStats',
+      summary: 'Get decision statistics',
+      description:
+        'Retrieve aggregate decision statistics for the tenant over a configurable time window.',
+      tags: ['Decisions'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          description: 'Number of days to look back for statistics.',
+          schema: { type: 'integer', minimum: 1, default: 30 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Decision statistics.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      total: {
+                        type: 'integer',
+                        minimum: 0,
+                        description: 'Total number of decisions in the period.',
+                      },
+                      by_status: {
+                        type: 'object',
+                        properties: {
+                          proposed: { type: 'integer', minimum: 0 },
+                          approved: { type: 'integer', minimum: 0 },
+                          rejected: { type: 'integer', minimum: 0 },
+                          overridden: { type: 'integer', minimum: 0 },
+                          executed: { type: 'integer', minimum: 0 },
+                        },
+                        additionalProperties: { type: 'integer' },
+                      },
+                      by_category: {
+                        type: 'object',
+                        properties: {
+                          action: { type: 'integer', minimum: 0 },
+                          resource: { type: 'integer', minimum: 0 },
+                          escalation: { type: 'integer', minimum: 0 },
+                          strategy: { type: 'integer', minimum: 0 },
+                          system: { type: 'integer', minimum: 0 },
+                        },
+                        additionalProperties: { type: 'integer' },
+                      },
+                      avg_confidence: {
+                        type: 'number',
+                        minimum: 0,
+                        maximum: 1,
+                        description: 'Average reasoning confidence across decisions.',
+                      },
+                      self_authorized_count: {
+                        type: 'integer',
+                        minimum: 0,
+                        description: 'Number of decisions that were self-authorized.',
+                      },
+                    },
+                    required: [
+                      'total',
+                      'by_status',
+                      'by_category',
+                      'avg_confidence',
+                      'self_authorized_count',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid query parameters.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Escalation Paths
+// ---------------------------------------------------------------------------
+
+export const escalationPaths = {
+  '/escalations': {
+    get: {
+      operationId: 'listEscalations',
+      summary: 'List escalations',
+      description:
+        'Retrieve a paginated list of escalations with optional filtering by status, urgency, type, agent, and full-text search.',
+      tags: ['Escalations'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'status',
+          in: 'query',
+          required: false,
+          description: 'Filter by escalation status.',
+          schema: {
+            type: 'string',
+            enum: ['open', 'in_progress', 'resolved', 'dismissed'],
+          },
+        },
+        {
+          name: 'urgency',
+          in: 'query',
+          required: false,
+          description: 'Filter by urgency level.',
+          schema: {
+            type: 'string',
+            enum: ['low', 'normal', 'high', 'critical'],
+          },
+        },
+        {
+          name: 'type',
+          in: 'query',
+          required: false,
+          description: 'Filter by escalation type.',
+          schema: {
+            type: 'string',
+            enum: ['clarification', 'approval', 'error', 'edge_case', 'policy_violation'],
+          },
+        },
+        {
+          name: 'agent_id',
+          in: 'query',
+          required: false,
+          description: 'Filter by the agent that raised the escalation.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+        {
+          name: 'search',
+          in: 'query',
+          required: false,
+          description: 'Full-text search across escalation title and description.',
+          schema: { type: 'string', minLength: 1, maxLength: 200 },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          required: false,
+          description: 'Page number (1-indexed).',
+          schema: { type: 'integer', minimum: 1, default: 1 },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of results per page.',
+          schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of escalations.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Escalation' },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                  pagination: { $ref: '#/components/schemas/Pagination' },
+                },
+                required: ['data', 'meta', 'pagination'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid query parameters.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'createEscalation',
+      summary: 'Create escalation',
+      description:
+        'Raise a new escalation on behalf of an agent. The escalation starts in the `open` status with the specified urgency.',
+      tags: ['Escalations'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/CreateEscalationInput' },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Escalation created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Escalation' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Referenced agent or task not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/escalations/{id}': {
+    get: {
+      operationId: 'getEscalation',
+      summary: 'Get escalation details',
+      description:
+        'Retrieve a single escalation by ID including expanded agent, task, and resolver relations.',
+      tags: ['Escalations'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Escalation UUID.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Escalation details with relations.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Escalation' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Escalation not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+    patch: {
+      operationId: 'updateEscalation',
+      summary: 'Update escalation',
+      description:
+        'Update mutable fields of an escalation such as status, urgency, title, and description.',
+      tags: ['Escalations'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Escalation UUID.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/UpdateEscalationInput' },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Escalation updated successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Escalation' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error or invalid state transition.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Escalation not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/escalations/{id}/resolve': {
+    post: {
+      operationId: 'resolveEscalation',
+      summary: 'Resolve escalation',
+      description:
+        'Resolve or dismiss an escalation by providing a resolution answer, type, optional resources, and learning notes.',
+      tags: ['Escalations'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Escalation UUID.',
+          schema: { type: 'string', format: 'uuid' },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/ResolveEscalationInput' },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Escalation resolved successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { $ref: '#/components/schemas/Escalation' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error or escalation already resolved.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '404': {
+          description: 'Escalation not found.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/escalations/stats': {
+    get: {
+      operationId: 'getEscalationStats',
+      summary: 'Get escalation statistics',
+      description:
+        'Retrieve aggregate escalation statistics for the tenant over a configurable time window.',
+      tags: ['Escalations'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          description: 'Number of days to look back for statistics.',
+          schema: { type: 'integer', minimum: 1, default: 30 },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Escalation statistics.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      total: {
+                        type: 'integer',
+                        minimum: 0,
+                        description: 'Total number of escalations in the period.',
+                      },
+                      by_status: {
+                        type: 'object',
+                        properties: {
+                          open: { type: 'integer', minimum: 0 },
+                          in_progress: { type: 'integer', minimum: 0 },
+                          resolved: { type: 'integer', minimum: 0 },
+                          dismissed: { type: 'integer', minimum: 0 },
+                        },
+                        additionalProperties: { type: 'integer' },
+                      },
+                      by_urgency: {
+                        type: 'object',
+                        properties: {
+                          low: { type: 'integer', minimum: 0 },
+                          normal: { type: 'integer', minimum: 0 },
+                          high: { type: 'integer', minimum: 0 },
+                          critical: { type: 'integer', minimum: 0 },
+                        },
+                        additionalProperties: { type: 'integer' },
+                      },
+                      by_type: {
+                        type: 'object',
+                        properties: {
+                          clarification: { type: 'integer', minimum: 0 },
+                          approval: { type: 'integer', minimum: 0 },
+                          error: { type: 'integer', minimum: 0 },
+                          edge_case: { type: 'integer', minimum: 0 },
+                          policy_violation: { type: 'integer', minimum: 0 },
+                        },
+                        additionalProperties: { type: 'integer' },
+                      },
+                      avg_resolution_time_seconds: {
+                        type: 'number',
+                        minimum: 0,
+                        description:
+                          'Average time in seconds from escalation creation to resolution.',
+                      },
+                    },
+                    required: [
+                      'total',
+                      'by_status',
+                      'by_urgency',
+                      'by_type',
+                      'avg_resolution_time_seconds',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: { type: 'string', format: 'date-time' },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid query parameters.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+        '401': {
+          description: 'Missing or invalid authentication token.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ErrorResponse' },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -1,0 +1,20 @@
+import { agentPaths } from './agents';
+import { taskPaths } from './tasks';
+import { decisionPaths, escalationPaths } from './decisions-escalations';
+import { messagePaths, activityPaths, chatPaths, templatePaths, analyticsPaths, metaAgentPaths } from './messages-activities';
+
+/**
+ * Merged OpenAPI paths for all ARM API endpoints
+ */
+export const allPaths = {
+  ...agentPaths,
+  ...taskPaths,
+  ...decisionPaths,
+  ...escalationPaths,
+  ...messagePaths,
+  ...activityPaths,
+  ...chatPaths,
+  ...templatePaths,
+  ...analyticsPaths,
+  ...metaAgentPaths,
+};

--- a/src/lib/openapi/messages-activities.ts
+++ b/src/lib/openapi/messages-activities.ts
@@ -1,0 +1,3820 @@
+export const messagePaths = {
+  '/messages': {
+    get: {
+      operationId: 'listMessages',
+      summary: 'List messages',
+      description:
+        'Retrieve a paginated list of messages for the current tenant. Supports filtering by sender, recipient, message type, thread, read status, and priority.',
+      tags: ['Messages'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'from_agent_id',
+          in: 'query',
+          required: false,
+          description: 'Filter messages sent by this agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'to_agent_id',
+          in: 'query',
+          required: false,
+          description: 'Filter messages addressed to this agent.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'message_type',
+          in: 'query',
+          required: false,
+          description: 'Filter messages by AAP message type.',
+          schema: {
+            type: 'string',
+            enum: [
+              'spawn.request',
+              'spawn.response',
+              'task.assign',
+              'task.accept',
+              'task.reject',
+              'task.progress',
+              'task.complete',
+              'task.fail',
+              'decision.propose',
+              'decision.confirm',
+              'decision.override',
+              'escalate.request',
+              'escalate.response',
+              'message.direct',
+              'message.broadcast',
+              'system.ping',
+              'system.pong',
+              'system.config.update',
+              'system.error',
+            ],
+          },
+        },
+        {
+          name: 'thread_id',
+          in: 'query',
+          required: false,
+          description: 'Filter messages belonging to a specific thread.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'unread_only',
+          in: 'query',
+          required: false,
+          description:
+            'When set to "true", return only unread/unacknowledged messages.',
+          schema: {
+            type: 'string',
+            enum: ['true', 'false'],
+            default: 'false',
+          },
+        },
+        {
+          name: 'priority',
+          in: 'query',
+          required: false,
+          description: 'Filter messages by priority level.',
+          schema: {
+            type: 'string',
+            enum: ['low', 'normal', 'high', 'urgent'],
+          },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          required: false,
+          description: 'Page number for pagination.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            default: 1,
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of messages per page.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 20,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of messages.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Message',
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                  pagination: {
+                    $ref: '#/components/schemas/Pagination',
+                  },
+                },
+                required: ['data', 'meta', 'pagination'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'sendMessage',
+      summary: 'Send message',
+      description:
+        'Send a new message between agents using the Agent-to-Agent Protocol (AAP). Supports direct messages, broadcasts, threaded conversations, and acknowledgment tracking.',
+      tags: ['Messages'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message_type: {
+                  type: 'string',
+                  description: 'The AAP message type.',
+                  enum: [
+                    'spawn.request',
+                    'spawn.response',
+                    'task.assign',
+                    'task.accept',
+                    'task.reject',
+                    'task.progress',
+                    'task.complete',
+                    'task.fail',
+                    'decision.propose',
+                    'decision.confirm',
+                    'decision.override',
+                    'escalate.request',
+                    'escalate.response',
+                    'message.direct',
+                    'message.broadcast',
+                    'system.ping',
+                    'system.pong',
+                    'system.config.update',
+                    'system.error',
+                  ],
+                },
+                from_agent_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description: 'The agent sending the message.',
+                },
+                to_agent_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description:
+                    'The target agent. Omit for broadcast messages.',
+                },
+                to_broadcast: {
+                  type: 'boolean',
+                  default: false,
+                  description:
+                    'When true, the message is broadcast to all agents in the tenant.',
+                },
+                thread_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description:
+                    'Thread identifier for grouping related messages.',
+                },
+                correlation_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description:
+                    'Correlation identifier linking request/response pairs.',
+                },
+                payload: {
+                  type: 'object',
+                  description:
+                    'The message payload. Structure varies by message_type.',
+                },
+                priority: {
+                  type: 'string',
+                  enum: ['low', 'normal', 'high', 'urgent'],
+                  default: 'normal',
+                  description: 'Message priority level.',
+                },
+                requires_ack: {
+                  type: 'boolean',
+                  default: false,
+                  description:
+                    'Whether the recipient must acknowledge receipt.',
+                },
+                trace: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                  description:
+                    'Trace path of agent IDs this message has traversed.',
+                },
+                expires_at: {
+                  type: 'string',
+                  format: 'date-time',
+                  description:
+                    'Optional expiration time after which the message is no longer valid.',
+                },
+                protocol_version: {
+                  type: 'string',
+                  default: '1.0',
+                  description: 'AAP protocol version.',
+                },
+              },
+              required: ['message_type', 'payload'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Message sent successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Message',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/messages/{id}': {
+    get: {
+      operationId: 'getMessage',
+      summary: 'Get message',
+      description:
+        'Retrieve a single message by its unique identifier, including expanded from_agent and to_agent references.',
+      tags: ['Messages'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the message.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'The requested message with expanded agent references.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    allOf: [
+                      { $ref: '#/components/schemas/Message' },
+                      {
+                        type: 'object',
+                        properties: {
+                          from_agent: {
+                            $ref: '#/components/schemas/Agent',
+                          },
+                          to_agent: {
+                            $ref: '#/components/schemas/Agent',
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Message not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/messages/{id}/read': {
+    patch: {
+      operationId: 'markMessageRead',
+      summary: 'Mark message as read/acknowledged',
+      description:
+        'Mark a message as read or acknowledged by setting the acked_at and/or processed_at timestamps.',
+      tags: ['Messages'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the message to mark as read.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: false,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                acked_at: {
+                  type: 'string',
+                  format: 'date-time',
+                  description:
+                    'Timestamp when the message was acknowledged by the recipient.',
+                },
+                processed_at: {
+                  type: 'string',
+                  format: 'date-time',
+                  description:
+                    'Timestamp when the message was fully processed by the recipient.',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Message marked as read/acknowledged.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Message',
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Message not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/messages/thread/{id}': {
+    get: {
+      operationId: 'getMessageThread',
+      summary: 'Get message thread',
+      description:
+        'Retrieve all messages belonging to a specific thread, ordered chronologically.',
+      tags: ['Messages'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'The thread identifier.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'All messages in the thread.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Message',
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Thread not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const activityPaths = {
+  '/activities': {
+    get: {
+      operationId: 'listActivities',
+      summary: 'List activities',
+      description:
+        'Retrieve a cursor-based paginated list of activities for the current tenant. Supports filtering by agent, entity type, action type, time range, and free-text search.',
+      tags: ['Activities'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'agent_id',
+          in: 'query',
+          required: false,
+          description: 'Filter activities by the agent that generated them.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'entity_type',
+          in: 'query',
+          required: false,
+          description: 'Filter activities by entity type category.',
+          schema: {
+            type: 'string',
+            enum: [
+              'all',
+              'tasks',
+              'decisions',
+              'escalations',
+              'agents',
+              'system',
+            ],
+          },
+        },
+        {
+          name: 'action_type',
+          in: 'query',
+          required: false,
+          description: 'Filter activities by specific action type.',
+          schema: {
+            type: 'string',
+            enum: [
+              'agent.spawned',
+              'agent.status_changed',
+              'agent.terminated',
+              'task.created',
+              'task.assigned',
+              'task.started',
+              'task.progress',
+              'task.completed',
+              'task.failed',
+              'decision.proposed',
+              'decision.made',
+              'decision.overridden',
+              'escalation.created',
+              'escalation.resolved',
+              'message.sent',
+              'message.received',
+              'system.error',
+              'system.config_changed',
+            ],
+          },
+        },
+        {
+          name: 'time_range',
+          in: 'query',
+          required: false,
+          description: 'Predefined time range filter.',
+          schema: {
+            type: 'string',
+            enum: ['1h', '24h', '7d', '30d', 'all'],
+          },
+        },
+        {
+          name: 'date_from',
+          in: 'query',
+          required: false,
+          description: 'Filter activities created on or after this timestamp.',
+          schema: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+        {
+          name: 'date_to',
+          in: 'query',
+          required: false,
+          description: 'Filter activities created on or before this timestamp.',
+          schema: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+        {
+          name: 'search',
+          in: 'query',
+          required: false,
+          description:
+            'Free-text search across activity descriptions and metadata.',
+          schema: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 200,
+          },
+        },
+        {
+          name: 'cursor',
+          in: 'query',
+          required: false,
+          description:
+            'Cursor for pagination. Pass the sequence_number from the last item in the previous page.',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of activities per page.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 50,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A cursor-based paginated list of activities.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Activity',
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                      next_cursor: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Cursor value to use for fetching the next page. Null when there are no more results.',
+                      },
+                    },
+                    required: ['timestamp', 'next_cursor'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const chatPaths = {
+  '/chats': {
+    get: {
+      operationId: 'listChats',
+      summary: 'List chats',
+      description:
+        'Retrieve all chats for the currently authenticated user, ordered by most recent activity.',
+      tags: ['Chats'],
+      security: [{ BearerAuth: [] }],
+      parameters: [],
+      responses: {
+        '200': {
+          description: 'A list of the user\'s chats.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description: 'Unique identifier of the chat.',
+                        },
+                        agent_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'The agent this chat is associated with.',
+                        },
+                        user_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description: 'The user who owns this chat.',
+                        },
+                        tenant_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description: 'The tenant this chat belongs to.',
+                        },
+                        last_message_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          nullable: true,
+                          description:
+                            'Timestamp of the most recent message in this chat.',
+                        },
+                        created_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description: 'Timestamp when the chat was created.',
+                        },
+                        updated_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the chat was last updated.',
+                        },
+                      },
+                      required: [
+                        'id',
+                        'agent_id',
+                        'user_id',
+                        'tenant_id',
+                        'created_at',
+                        'updated_at',
+                      ],
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'createChat',
+      summary: 'Create or get chat with agent',
+      description:
+        'Create a new chat with an agent, or return the existing chat if one already exists for the given agent and user combination.',
+      tags: ['Chats'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                agent_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description:
+                    'The agent to create or retrieve a chat with.',
+                },
+              },
+              required: ['agent_id'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'An existing chat was found and returned.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'Unique identifier of the chat.',
+                      },
+                      agent_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The agent this chat is associated with.',
+                      },
+                      user_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The user who owns this chat.',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The tenant this chat belongs to.',
+                      },
+                      last_message_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        nullable: true,
+                        description:
+                          'Timestamp of the most recent message in this chat.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Timestamp when the chat was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the chat was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'agent_id',
+                      'user_id',
+                      'tenant_id',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '201': {
+          description: 'A new chat was created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'Unique identifier of the chat.',
+                      },
+                      agent_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The agent this chat is associated with.',
+                      },
+                      user_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The user who owns this chat.',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The tenant this chat belongs to.',
+                      },
+                      last_message_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        nullable: true,
+                        description:
+                          'Timestamp of the most recent message in this chat.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Timestamp when the chat was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the chat was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'agent_id',
+                      'user_id',
+                      'tenant_id',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/chats/{id}/messages': {
+    get: {
+      operationId: 'listChatMessages',
+      summary: 'Get chat messages',
+      description:
+        'Retrieve messages in a chat, ordered by most recent first. Supports cursor-based pagination using the before parameter.',
+      tags: ['Chats'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the chat.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of messages to return.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 50,
+          },
+        },
+        {
+          name: 'before',
+          in: 'query',
+          required: false,
+          description:
+            'Return messages created before this timestamp for cursor-based pagination.',
+          schema: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A list of chat messages.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'Unique identifier of the chat message.',
+                        },
+                        chat_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'The chat this message belongs to.',
+                        },
+                        sender_type: {
+                          type: 'string',
+                          enum: ['user', 'agent'],
+                          description:
+                            'Whether the message was sent by a user or an agent.',
+                        },
+                        sender_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'The unique identifier of the sender (user or agent).',
+                        },
+                        content: {
+                          type: 'string',
+                          description: 'The message text content.',
+                        },
+                        created_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the message was created.',
+                        },
+                        updated_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the message was last updated.',
+                        },
+                      },
+                      required: [
+                        'id',
+                        'chat_id',
+                        'sender_type',
+                        'sender_id',
+                        'content',
+                        'created_at',
+                        'updated_at',
+                      ],
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Chat not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'sendChatMessage',
+      summary: 'Send message in chat',
+      description:
+        'Send a new message in an existing chat conversation. The sender is determined by the authenticated user.',
+      tags: ['Chats'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the chat.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                content: {
+                  type: 'string',
+                  minLength: 1,
+                  maxLength: 4000,
+                  description: 'The message text content.',
+                },
+              },
+              required: ['content'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Chat message sent successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the chat message.',
+                      },
+                      chat_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The chat this message belongs to.',
+                      },
+                      sender_type: {
+                        type: 'string',
+                        enum: ['user', 'agent'],
+                        description:
+                          'Whether the message was sent by a user or an agent.',
+                      },
+                      sender_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The unique identifier of the sender.',
+                      },
+                      content: {
+                        type: 'string',
+                        description: 'The message text content.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the message was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the message was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'chat_id',
+                      'sender_type',
+                      'sender_id',
+                      'content',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Chat not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/chats/{id}/messages/{messageId}': {
+    get: {
+      operationId: 'getChatMessage',
+      summary: 'Get chat message',
+      description:
+        'Retrieve a single chat message by its unique identifier within a chat.',
+      tags: ['Chats'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the chat.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'messageId',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the chat message.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'The requested chat message.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the chat message.',
+                      },
+                      chat_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The chat this message belongs to.',
+                      },
+                      sender_type: {
+                        type: 'string',
+                        enum: ['user', 'agent'],
+                        description:
+                          'Whether the message was sent by a user or an agent.',
+                      },
+                      sender_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The unique identifier of the sender.',
+                      },
+                      content: {
+                        type: 'string',
+                        description: 'The message text content.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the message was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the message was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'chat_id',
+                      'sender_type',
+                      'sender_id',
+                      'content',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Chat or message not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    delete: {
+      operationId: 'deleteChatMessage',
+      summary: 'Delete chat message',
+      description:
+        'Delete a chat message by its unique identifier within a chat.',
+      tags: ['Chats'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the chat.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'messageId',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the chat message to delete.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Chat message deleted successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The identifier of the deleted chat message.',
+                      },
+                      deleted: {
+                        type: 'boolean',
+                        description:
+                          'Always true on successful deletion.',
+                        enum: [true],
+                      },
+                    },
+                    required: ['id', 'deleted'],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Chat or message not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const templatePaths = {
+  '/agent-templates': {
+    get: {
+      operationId: 'listAgentTemplates',
+      summary: 'List agent templates',
+      description:
+        'Retrieve a paginated list of agent templates, including both system-provided templates and tenant-specific custom templates. Supports filtering by category and free-text search.',
+      tags: ['Agent Templates'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'category',
+          in: 'query',
+          required: false,
+          description: 'Filter templates by category.',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'search',
+          in: 'query',
+          required: false,
+          description:
+            'Free-text search across template name and description.',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          required: false,
+          description: 'Page number for pagination.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            default: 1,
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of templates per page.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 20,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of agent templates.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'Unique identifier of the template.',
+                        },
+                        tenant_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          nullable: true,
+                          description:
+                            'The tenant that owns this template. Null for system templates.',
+                        },
+                        name: {
+                          type: 'string',
+                          description: 'Display name of the template.',
+                        },
+                        description: {
+                          type: 'string',
+                          nullable: true,
+                          description:
+                            'Human-readable description of what the template provides.',
+                        },
+                        category: {
+                          type: 'string',
+                          nullable: true,
+                          description:
+                            'Category grouping for the template.',
+                        },
+                        role: {
+                          type: 'string',
+                          enum: [
+                            'ceo',
+                            'manager',
+                            'worker',
+                            'specialist',
+                            'system',
+                          ],
+                          nullable: true,
+                          description:
+                            'Default agent role assigned by this template.',
+                        },
+                        config: {
+                          type: 'object',
+                          nullable: true,
+                          description:
+                            'Default configuration applied when using this template.',
+                        },
+                        is_system: {
+                          type: 'boolean',
+                          description:
+                            'Whether this is a built-in system template.',
+                        },
+                        created_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the template was created.',
+                        },
+                        updated_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the template was last updated.',
+                        },
+                      },
+                      required: [
+                        'id',
+                        'name',
+                        'is_system',
+                        'created_at',
+                        'updated_at',
+                      ],
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                  pagination: {
+                    $ref: '#/components/schemas/Pagination',
+                  },
+                },
+                required: ['data', 'meta', 'pagination'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'createAgentTemplate',
+      summary: 'Create custom agent template',
+      description:
+        'Create a new custom agent template for the current tenant. Custom templates can be used as starting points when spawning new agents.',
+      tags: ['Agent Templates'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                  description: 'Display name of the template.',
+                },
+                description: {
+                  type: 'string',
+                  nullable: true,
+                  description:
+                    'Human-readable description of what the template provides.',
+                },
+                category: {
+                  type: 'string',
+                  nullable: true,
+                  description: 'Category grouping for the template.',
+                },
+                role: {
+                  type: 'string',
+                  enum: [
+                    'ceo',
+                    'manager',
+                    'worker',
+                    'specialist',
+                    'system',
+                  ],
+                  nullable: true,
+                  description:
+                    'Default agent role assigned by this template.',
+                },
+                config: {
+                  type: 'object',
+                  nullable: true,
+                  description:
+                    'Default configuration applied when using this template.',
+                },
+              },
+              required: ['name'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Agent template created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the template.',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        nullable: true,
+                        description:
+                          'The tenant that owns this template.',
+                      },
+                      name: {
+                        type: 'string',
+                        description: 'Display name of the template.',
+                      },
+                      description: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Human-readable description of what the template provides.',
+                      },
+                      category: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Category grouping for the template.',
+                      },
+                      role: {
+                        type: 'string',
+                        enum: [
+                          'ceo',
+                          'manager',
+                          'worker',
+                          'specialist',
+                          'system',
+                        ],
+                        nullable: true,
+                        description:
+                          'Default agent role assigned by this template.',
+                      },
+                      config: {
+                        type: 'object',
+                        nullable: true,
+                        description:
+                          'Default configuration applied when using this template.',
+                      },
+                      is_system: {
+                        type: 'boolean',
+                        description:
+                          'Whether this is a built-in system template.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the template was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the template was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'name',
+                      'is_system',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/agent-templates/{id}': {
+    get: {
+      operationId: 'getAgentTemplate',
+      summary: 'Get agent template details',
+      description:
+        'Retrieve a single agent template by its unique identifier, including full configuration details.',
+      tags: ['Agent Templates'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent template.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'The requested agent template.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the template.',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        nullable: true,
+                        description:
+                          'The tenant that owns this template. Null for system templates.',
+                      },
+                      name: {
+                        type: 'string',
+                        description: 'Display name of the template.',
+                      },
+                      description: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Human-readable description of what the template provides.',
+                      },
+                      category: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Category grouping for the template.',
+                      },
+                      role: {
+                        type: 'string',
+                        enum: [
+                          'ceo',
+                          'manager',
+                          'worker',
+                          'specialist',
+                          'system',
+                        ],
+                        nullable: true,
+                        description:
+                          'Default agent role assigned by this template.',
+                      },
+                      config: {
+                        type: 'object',
+                        nullable: true,
+                        description:
+                          'Default configuration applied when using this template.',
+                      },
+                      is_system: {
+                        type: 'boolean',
+                        description:
+                          'Whether this is a built-in system template.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the template was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the template was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'name',
+                      'is_system',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent template not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    patch: {
+      operationId: 'updateAgentTemplate',
+      summary: 'Update agent template',
+      description:
+        'Partially update an existing custom agent template. Only the fields provided in the request body are modified. System templates cannot be updated.',
+      tags: ['Agent Templates'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent template to update.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                  description: 'Display name of the template.',
+                },
+                description: {
+                  type: 'string',
+                  nullable: true,
+                  description:
+                    'Human-readable description of what the template provides.',
+                },
+                category: {
+                  type: 'string',
+                  nullable: true,
+                  description: 'Category grouping for the template.',
+                },
+                config: {
+                  type: 'object',
+                  nullable: true,
+                  description:
+                    'Default configuration applied when using this template.',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Agent template updated successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the template.',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        nullable: true,
+                        description:
+                          'The tenant that owns this template.',
+                      },
+                      name: {
+                        type: 'string',
+                        description: 'Display name of the template.',
+                      },
+                      description: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Human-readable description of what the template provides.',
+                      },
+                      category: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Category grouping for the template.',
+                      },
+                      role: {
+                        type: 'string',
+                        enum: [
+                          'ceo',
+                          'manager',
+                          'worker',
+                          'specialist',
+                          'system',
+                        ],
+                        nullable: true,
+                        description:
+                          'Default agent role assigned by this template.',
+                      },
+                      config: {
+                        type: 'object',
+                        nullable: true,
+                        description:
+                          'Default configuration applied when using this template.',
+                      },
+                      is_system: {
+                        type: 'boolean',
+                        description:
+                          'Whether this is a built-in system template.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the template was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the template was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'name',
+                      'is_system',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Validation error.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent template not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    delete: {
+      operationId: 'deleteAgentTemplate',
+      summary: 'Delete agent template',
+      description:
+        'Delete a custom agent template. System templates cannot be deleted.',
+      tags: ['Agent Templates'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the agent template to delete.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Agent template deleted successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The identifier of the deleted template.',
+                      },
+                      deleted: {
+                        type: 'boolean',
+                        description:
+                          'Always true on successful deletion.',
+                        enum: [true],
+                      },
+                    },
+                    required: ['id', 'deleted'],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent template not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const analyticsPaths = {
+  '/analytics/overview': {
+    get: {
+      operationId: 'getAnalyticsOverview',
+      summary: 'Dashboard metrics with trends',
+      description:
+        'Retrieve aggregated dashboard metrics including agent counts, task statistics, escalation data, cost totals, and trend comparisons. Results are cached for 5 minutes.',
+      tags: ['Analytics'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          description: 'Number of days to include in the analytics window.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 90,
+            default: 30,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description:
+            'Aggregated dashboard metrics with trend comparisons.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      agents: {
+                        type: 'object',
+                        properties: {
+                          total: {
+                            type: 'integer',
+                            description:
+                              'Total number of agents in the tenant.',
+                          },
+                          active: {
+                            type: 'integer',
+                            description:
+                              'Number of agents currently in active status.',
+                          },
+                          idle: {
+                            type: 'integer',
+                            description:
+                              'Number of agents currently in idle status.',
+                          },
+                          error: {
+                            type: 'integer',
+                            description:
+                              'Number of agents currently in error status.',
+                          },
+                        },
+                        required: ['total', 'active', 'idle', 'error'],
+                      },
+                      tasks: {
+                        type: 'object',
+                        properties: {
+                          total: {
+                            type: 'integer',
+                            description:
+                              'Total number of tasks in the analytics window.',
+                          },
+                          completed: {
+                            type: 'integer',
+                            description:
+                              'Number of tasks completed in the analytics window.',
+                          },
+                          in_progress: {
+                            type: 'integer',
+                            description:
+                              'Number of tasks currently in progress.',
+                          },
+                          failed: {
+                            type: 'integer',
+                            description:
+                              'Number of tasks that failed in the analytics window.',
+                          },
+                          completion_rate: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Percentage of tasks completed successfully (0-100).',
+                          },
+                        },
+                        required: [
+                          'total',
+                          'completed',
+                          'in_progress',
+                          'failed',
+                          'completion_rate',
+                        ],
+                      },
+                      escalations: {
+                        type: 'object',
+                        properties: {
+                          total: {
+                            type: 'integer',
+                            description:
+                              'Total number of escalations in the analytics window.',
+                          },
+                          open: {
+                            type: 'integer',
+                            description:
+                              'Number of currently open escalations.',
+                          },
+                          resolved: {
+                            type: 'integer',
+                            description:
+                              'Number of escalations resolved in the analytics window.',
+                          },
+                          avg_resolution_time: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Average escalation resolution time in seconds.',
+                          },
+                        },
+                        required: [
+                          'total',
+                          'open',
+                          'resolved',
+                          'avg_resolution_time',
+                        ],
+                      },
+                      cost: {
+                        type: 'object',
+                        properties: {
+                          total_usd: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Total cost in USD during the analytics window.',
+                          },
+                          avg_per_task: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Average cost per task in USD.',
+                          },
+                        },
+                        required: ['total_usd', 'avg_per_task'],
+                      },
+                      trends: {
+                        type: 'object',
+                        description:
+                          'Trend comparisons against the previous period of equal length.',
+                      },
+                    },
+                    required: [
+                      'agents',
+                      'tasks',
+                      'escalations',
+                      'cost',
+                      'trends',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                      cached: {
+                        type: 'boolean',
+                        description:
+                          'Whether this response was served from cache.',
+                      },
+                    },
+                    required: ['timestamp', 'cached'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/analytics/agents/{id}': {
+    get: {
+      operationId: 'getAgentAnalytics',
+      summary: 'Agent performance analytics',
+      description:
+        'Retrieve detailed performance analytics for a specific agent, including task completion rates, cost breakdown, decision accuracy, and escalation metrics.',
+      tags: ['Analytics'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description:
+            'Unique identifier of the agent to retrieve analytics for.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          description: 'Number of days to include in the analytics window.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 90,
+            default: 30,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Detailed agent performance analytics.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      agent: {
+                        $ref: '#/components/schemas/Agent',
+                      },
+                      tasks: {
+                        type: 'object',
+                        properties: {
+                          completed: {
+                            type: 'integer',
+                            description:
+                              'Number of tasks completed by this agent.',
+                          },
+                          failed: {
+                            type: 'integer',
+                            description:
+                              'Number of tasks failed by this agent.',
+                          },
+                          avg_duration: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Average task duration in seconds.',
+                          },
+                        },
+                        required: [
+                          'completed',
+                          'failed',
+                          'avg_duration',
+                        ],
+                      },
+                      cost: {
+                        type: 'object',
+                        properties: {
+                          total_usd: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Total cost incurred by this agent in USD.',
+                          },
+                        },
+                        required: ['total_usd'],
+                      },
+                      decisions: {
+                        type: 'object',
+                        properties: {
+                          total: {
+                            type: 'integer',
+                            description:
+                              'Total number of decisions made by this agent.',
+                          },
+                          approved_rate: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Percentage of decisions that were approved (0-100).',
+                          },
+                        },
+                        required: ['total', 'approved_rate'],
+                      },
+                      escalations: {
+                        type: 'object',
+                        properties: {
+                          total: {
+                            type: 'integer',
+                            description:
+                              'Total number of escalations involving this agent.',
+                          },
+                          resolution_rate: {
+                            type: 'number',
+                            format: 'float',
+                            description:
+                              'Percentage of escalations resolved (0-100).',
+                          },
+                        },
+                        required: ['total', 'resolution_rate'],
+                      },
+                    },
+                    required: [
+                      'agent',
+                      'tasks',
+                      'cost',
+                      'decisions',
+                      'escalations',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Agent not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/analytics/leaderboard': {
+    get: {
+      operationId: 'getAgentLeaderboard',
+      summary: 'Agent leaderboard',
+      description:
+        'Retrieve a ranked leaderboard of agents based on performance metrics. Supports sorting by tasks completed, success rate, average duration, or cost.',
+      tags: ['Analytics'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          description: 'Number of days to include in the analytics window.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 90,
+            default: 30,
+          },
+        },
+        {
+          name: 'sortBy',
+          in: 'query',
+          required: false,
+          description: 'Metric to sort the leaderboard by.',
+          schema: {
+            type: 'string',
+            enum: [
+              'tasksCompleted',
+              'successRate',
+              'avgDuration',
+              'cost',
+            ],
+            default: 'tasksCompleted',
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          required: false,
+          description: 'Number of agents to include in the leaderboard.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 20,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A ranked list of agent performance entries.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        rank: {
+                          type: 'integer',
+                          description:
+                            'The agent\'s position in the leaderboard.',
+                        },
+                        agent_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description: 'Unique identifier of the agent.',
+                        },
+                        agent_name: {
+                          type: 'string',
+                          description: 'Display name of the agent.',
+                        },
+                        agent_role: {
+                          type: 'string',
+                          enum: [
+                            'ceo',
+                            'manager',
+                            'worker',
+                            'specialist',
+                            'system',
+                          ],
+                          description:
+                            'The organizational role of the agent.',
+                        },
+                        tasks_completed: {
+                          type: 'integer',
+                          description:
+                            'Number of tasks completed by this agent.',
+                        },
+                        success_rate: {
+                          type: 'number',
+                          format: 'float',
+                          description:
+                            'Task success rate percentage (0-100).',
+                        },
+                        avg_duration: {
+                          type: 'number',
+                          format: 'float',
+                          description:
+                            'Average task duration in seconds.',
+                        },
+                        total_cost_usd: {
+                          type: 'number',
+                          format: 'float',
+                          description:
+                            'Total cost incurred by this agent in USD.',
+                        },
+                      },
+                      required: [
+                        'rank',
+                        'agent_id',
+                        'agent_name',
+                        'agent_role',
+                        'tasks_completed',
+                        'success_rate',
+                        'avg_duration',
+                        'total_cost_usd',
+                      ],
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/analytics/bottlenecks': {
+    get: {
+      operationId: 'getBottleneckAnalysis',
+      summary: 'System bottleneck analysis',
+      description:
+        'Identify system bottlenecks including blocked tasks, slow agents, overloaded agents, and escalation hotspots within the specified time window.',
+      tags: ['Analytics'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'hours',
+          in: 'query',
+          required: false,
+          description:
+            'Number of hours to look back for bottleneck analysis.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 168,
+            default: 24,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'System bottleneck analysis results.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      blocked_tasks: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            task_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Unique identifier of the blocked task.',
+                            },
+                            task_title: {
+                              type: 'string',
+                              description: 'Title of the blocked task.',
+                            },
+                            blocked_since: {
+                              type: 'string',
+                              format: 'date-time',
+                              description:
+                                'Timestamp when the task became blocked.',
+                            },
+                            blocked_by: {
+                              type: 'string',
+                              nullable: true,
+                              description:
+                                'Description of what is blocking the task.',
+                            },
+                            assigned_agent_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              nullable: true,
+                              description:
+                                'Agent assigned to this task, if any.',
+                            },
+                          },
+                          required: [
+                            'task_id',
+                            'task_title',
+                            'blocked_since',
+                          ],
+                        },
+                        description:
+                          'Tasks that are currently in blocked status.',
+                      },
+                      slow_agents: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            agent_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Unique identifier of the slow agent.',
+                            },
+                            agent_name: {
+                              type: 'string',
+                              description: 'Display name of the agent.',
+                            },
+                            avg_task_duration: {
+                              type: 'number',
+                              format: 'float',
+                              description:
+                                'Average task duration in seconds, significantly above the norm.',
+                            },
+                            tasks_in_progress: {
+                              type: 'integer',
+                              description:
+                                'Number of tasks currently in progress for this agent.',
+                            },
+                          },
+                          required: [
+                            'agent_id',
+                            'agent_name',
+                            'avg_task_duration',
+                            'tasks_in_progress',
+                          ],
+                        },
+                        description:
+                          'Agents with task durations significantly above average.',
+                      },
+                      overloaded_agents: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            agent_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Unique identifier of the overloaded agent.',
+                            },
+                            agent_name: {
+                              type: 'string',
+                              description: 'Display name of the agent.',
+                            },
+                            active_tasks: {
+                              type: 'integer',
+                              description:
+                                'Number of tasks currently assigned to this agent.',
+                            },
+                            max_concurrent: {
+                              type: 'integer',
+                              description:
+                                'Maximum concurrent tasks configured for this agent.',
+                            },
+                          },
+                          required: [
+                            'agent_id',
+                            'agent_name',
+                            'active_tasks',
+                            'max_concurrent',
+                          ],
+                        },
+                        description:
+                          'Agents that are at or above their maximum concurrent task limit.',
+                      },
+                      escalation_hotspots: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            agent_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Unique identifier of the agent with frequent escalations.',
+                            },
+                            agent_name: {
+                              type: 'string',
+                              description: 'Display name of the agent.',
+                            },
+                            escalation_count: {
+                              type: 'integer',
+                              description:
+                                'Number of escalations involving this agent in the time window.',
+                            },
+                            unresolved_count: {
+                              type: 'integer',
+                              description:
+                                'Number of unresolved escalations for this agent.',
+                            },
+                          },
+                          required: [
+                            'agent_id',
+                            'agent_name',
+                            'escalation_count',
+                            'unresolved_count',
+                          ],
+                        },
+                        description:
+                          'Agents generating a disproportionate number of escalations.',
+                      },
+                    },
+                    required: [
+                      'blocked_tasks',
+                      'slow_agents',
+                      'overloaded_agents',
+                      'escalation_hotspots',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/analytics/roi': {
+    get: {
+      operationId: 'getROIAnalysis',
+      summary: 'ROI analysis',
+      description:
+        'Calculate return on investment by comparing agent operational costs against estimated human labor costs for the same work volume.',
+      tags: ['Analytics'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'days',
+          in: 'query',
+          required: false,
+          description: 'Number of days to include in the ROI calculation.',
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 90,
+            default: 30,
+          },
+        },
+        {
+          name: 'hourlyRate',
+          in: 'query',
+          required: false,
+          description:
+            'Assumed human hourly rate in USD for comparison.',
+          schema: {
+            type: 'number',
+            default: 50,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'ROI analysis results.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      total_cost: {
+                        type: 'number',
+                        format: 'float',
+                        description:
+                          'Total agent operational cost in USD during the period.',
+                      },
+                      estimated_human_hours: {
+                        type: 'number',
+                        format: 'float',
+                        description:
+                          'Estimated number of human hours required for the same work.',
+                      },
+                      estimated_human_cost: {
+                        type: 'number',
+                        format: 'float',
+                        description:
+                          'Estimated human labor cost in USD based on the hourly rate.',
+                      },
+                      roi_percentage: {
+                        type: 'number',
+                        format: 'float',
+                        description:
+                          'ROI percentage. Positive values indicate cost savings.',
+                      },
+                      cost_per_task: {
+                        type: 'number',
+                        format: 'float',
+                        description:
+                          'Average agent cost per task in USD.',
+                      },
+                    },
+                    required: [
+                      'total_cost',
+                      'estimated_human_hours',
+                      'estimated_human_cost',
+                      'roi_percentage',
+                      'cost_per_task',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const metaAgentPaths = {
+  '/meta-agent/process': {
+    post: {
+      operationId: 'processMetaAgentMessage',
+      summary: 'Process CEO message through natural language interface',
+      description:
+        'Send a natural language message to the VALIS meta-agent for processing. VALIS interprets the intent, executes any required actions (agent spawning, task creation, etc.), and returns a natural language response.',
+      tags: ['Meta-Agent'],
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                  description:
+                    'The natural language message to process.',
+                },
+                session_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description:
+                    'Optional session identifier to continue a previous conversation. If omitted, a new session is created.',
+                },
+              },
+              required: ['message'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Meta-agent processing result.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      response: {
+                        type: 'string',
+                        description:
+                          'The natural language response from VALIS.',
+                      },
+                      intent: {
+                        type: 'string',
+                        description:
+                          'The detected intent classification of the input message.',
+                      },
+                      actions_taken: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            type: {
+                              type: 'string',
+                              description:
+                                'The type of action performed (e.g., agent.spawn, task.create).',
+                            },
+                            description: {
+                              type: 'string',
+                              description:
+                                'Human-readable description of the action taken.',
+                            },
+                            entity_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              nullable: true,
+                              description:
+                                'The identifier of the entity created or modified, if applicable.',
+                            },
+                          },
+                          required: ['type', 'description'],
+                        },
+                        description:
+                          'List of actions the meta-agent performed in response to the message.',
+                      },
+                      session_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The session identifier for this conversation.',
+                      },
+                    },
+                    required: [
+                      'response',
+                      'intent',
+                      'actions_taken',
+                      'session_id',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/meta-agent/sessions': {
+    get: {
+      operationId: 'listMetaAgentSessions',
+      summary: 'List meta-agent sessions',
+      description:
+        'Retrieve all VALIS meta-agent sessions for the current user, ordered by most recent activity.',
+      tags: ['Meta-Agent'],
+      security: [{ BearerAuth: [] }],
+      parameters: [],
+      responses: {
+        '200': {
+          description: 'A list of meta-agent sessions.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'Unique identifier of the session.',
+                        },
+                        user_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'The user who owns this session.',
+                        },
+                        tenant_id: {
+                          type: 'string',
+                          format: 'uuid',
+                          description:
+                            'The tenant this session belongs to.',
+                        },
+                        title: {
+                          type: 'string',
+                          nullable: true,
+                          description:
+                            'Auto-generated or user-provided title summarizing the session.',
+                        },
+                        status: {
+                          type: 'string',
+                          enum: ['active', 'archived'],
+                          description:
+                            'Current status of the session.',
+                        },
+                        command_count: {
+                          type: 'integer',
+                          description:
+                            'Total number of commands processed in this session.',
+                        },
+                        last_activity_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          nullable: true,
+                          description:
+                            'Timestamp of the most recent activity in this session.',
+                        },
+                        created_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the session was created.',
+                        },
+                        updated_at: {
+                          type: 'string',
+                          format: 'date-time',
+                          description:
+                            'Timestamp when the session was last updated.',
+                        },
+                      },
+                      required: [
+                        'id',
+                        'user_id',
+                        'tenant_id',
+                        'status',
+                        'command_count',
+                        'created_at',
+                        'updated_at',
+                      ],
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/meta-agent/sessions/{id}': {
+    get: {
+      operationId: 'getMetaAgentSession',
+      summary: 'Get meta-agent session with command history',
+      description:
+        'Retrieve a single meta-agent session by its unique identifier, including the full command history and responses.',
+      tags: ['Meta-Agent'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description: 'Unique identifier of the meta-agent session.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description:
+            'The requested meta-agent session with command history.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the session.',
+                      },
+                      user_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The user who owns this session.',
+                      },
+                      tenant_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'The tenant this session belongs to.',
+                      },
+                      title: {
+                        type: 'string',
+                        nullable: true,
+                        description:
+                          'Auto-generated or user-provided title summarizing the session.',
+                      },
+                      status: {
+                        type: 'string',
+                        enum: ['active', 'archived'],
+                        description:
+                          'Current status of the session.',
+                      },
+                      command_count: {
+                        type: 'integer',
+                        description:
+                          'Total number of commands processed in this session.',
+                      },
+                      last_activity_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        nullable: true,
+                        description:
+                          'Timestamp of the most recent activity in this session.',
+                      },
+                      commands: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Unique identifier of the command.',
+                            },
+                            message: {
+                              type: 'string',
+                              description:
+                                'The user\'s input message.',
+                            },
+                            response: {
+                              type: 'string',
+                              description:
+                                'The VALIS response to the command.',
+                            },
+                            intent: {
+                              type: 'string',
+                              description:
+                                'The detected intent classification.',
+                            },
+                            actions_taken: {
+                              type: 'array',
+                              items: {
+                                type: 'object',
+                                properties: {
+                                  type: {
+                                    type: 'string',
+                                    description:
+                                      'The type of action performed.',
+                                  },
+                                  description: {
+                                    type: 'string',
+                                    description:
+                                      'Human-readable description of the action.',
+                                  },
+                                  entity_id: {
+                                    type: 'string',
+                                    format: 'uuid',
+                                    nullable: true,
+                                    description:
+                                      'The identifier of the entity created or modified.',
+                                  },
+                                },
+                                required: ['type', 'description'],
+                              },
+                              description:
+                                'Actions performed for this command.',
+                            },
+                            created_at: {
+                              type: 'string',
+                              format: 'date-time',
+                              description:
+                                'Timestamp when the command was processed.',
+                            },
+                          },
+                          required: [
+                            'id',
+                            'message',
+                            'response',
+                            'intent',
+                            'actions_taken',
+                            'created_at',
+                          ],
+                        },
+                        description:
+                          'The full command history for this session, ordered chronologically.',
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the session was created.',
+                      },
+                      updated_at: {
+                        type: 'string',
+                        format: 'date-time',
+                        description:
+                          'Timestamp when the session was last updated.',
+                      },
+                    },
+                    required: [
+                      'id',
+                      'user_id',
+                      'tenant_id',
+                      'status',
+                      'command_count',
+                      'commands',
+                      'created_at',
+                      'updated_at',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Session not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      operationId: 'continueMetaAgentSession',
+      summary: 'Continue meta-agent session',
+      description:
+        'Send a follow-up message within an existing VALIS meta-agent session, maintaining conversation context.',
+      tags: ['Meta-Agent'],
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          description:
+            'Unique identifier of the meta-agent session to continue.',
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                  description:
+                    'The natural language follow-up message to process.',
+                },
+              },
+              required: ['message'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Meta-agent session continued successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      response: {
+                        type: 'string',
+                        description:
+                          'The natural language response from VALIS.',
+                      },
+                      intent: {
+                        type: 'string',
+                        description:
+                          'The detected intent classification of the input message.',
+                      },
+                      actions_taken: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            type: {
+                              type: 'string',
+                              description:
+                                'The type of action performed.',
+                            },
+                            description: {
+                              type: 'string',
+                              description:
+                                'Human-readable description of the action taken.',
+                            },
+                            entity_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              nullable: true,
+                              description:
+                                'The identifier of the entity created or modified, if applicable.',
+                            },
+                          },
+                          required: ['type', 'description'],
+                        },
+                        description:
+                          'List of actions the meta-agent performed in response to the message.',
+                      },
+                    },
+                    required: [
+                      'response',
+                      'intent',
+                      'actions_taken',
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                    required: ['timestamp'],
+                  },
+                },
+                required: ['data', 'meta'],
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Validation error. The request body failed schema or business-rule validation.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ValidationError',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Session not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/lib/openapi/tasks.ts
+++ b/src/lib/openapi/tasks.ts
@@ -1,0 +1,1262 @@
+export const taskPaths = {
+  '/tasks': {
+    get: {
+      tags: ['Tasks'],
+      operationId: 'listTasks',
+      summary: 'List tasks',
+      description:
+        'Retrieve a paginated list of tasks with advanced filtering, sorting, and search capabilities.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'status',
+          in: 'query',
+          description:
+            'Comma-separated list of task statuses to filter by.',
+          required: false,
+          schema: {
+            type: 'string',
+            example: 'queued,in_progress',
+          },
+          explode: false,
+          style: 'form',
+        },
+        {
+          name: 'priority',
+          in: 'query',
+          description: 'Filter by task priority.',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['low', 'normal', 'high', 'urgent'],
+          },
+        },
+        {
+          name: 'agent_id',
+          in: 'query',
+          description: 'Filter by the agent that created or owns the task.',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'assignee_id',
+          in: 'query',
+          description: 'Filter by the agent assigned to the task.',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'parent_id',
+          in: 'query',
+          description:
+            'Filter by parent task ID. Use null to retrieve only root-level tasks.',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+            nullable: true,
+          },
+        },
+        {
+          name: 'due_before',
+          in: 'query',
+          description:
+            'Filter tasks with a deadline before this datetime (ISO 8601).',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+        {
+          name: 'due_after',
+          in: 'query',
+          description:
+            'Filter tasks with a deadline after this datetime (ISO 8601).',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+        {
+          name: 'search',
+          in: 'query',
+          description:
+            'Full-text search across task title and description.',
+          required: false,
+          schema: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 200,
+          },
+        },
+        {
+          name: 'sort',
+          in: 'query',
+          description: 'Field to sort results by.',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['created_at', 'updated_at', 'deadline_at', 'priority'],
+            default: 'created_at',
+          },
+        },
+        {
+          name: 'order',
+          in: 'query',
+          description: 'Sort order.',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['asc', 'desc'],
+            default: 'desc',
+          },
+        },
+        {
+          name: 'page',
+          in: 'query',
+          description: 'Page number for pagination.',
+          required: false,
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            default: 1,
+          },
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          description: 'Number of results per page.',
+          required: false,
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            default: 20,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'A paginated list of tasks matching the filter criteria.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta', 'pagination'],
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Task',
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                  pagination: {
+                    $ref: '#/components/schemas/Pagination',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid query parameters.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      tags: ['Tasks'],
+      operationId: 'createTask',
+      summary: 'Create task',
+      description: 'Create a new task with the provided details.',
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/CreateTaskInput',
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Task created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Task',
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid request body.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description:
+            'Referenced resource not found (assignee, parent task).',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/tasks/{id}': {
+    get: {
+      tags: ['Tasks'],
+      operationId: 'getTask',
+      summary: 'Get single task',
+      description:
+        'Retrieve a single task by ID, including its assignee, assigner, subtasks, and dependencies.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'Unique identifier of the task.',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description:
+            'Task details including assignee, assigner, subtasks, and dependencies.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    allOf: [
+                      {
+                        $ref: '#/components/schemas/Task',
+                      },
+                      {
+                        type: 'object',
+                        properties: {
+                          assignee: {
+                            type: 'object',
+                            nullable: true,
+                            description:
+                              'The agent assigned to this task.',
+                            properties: {
+                              id: {
+                                type: 'string',
+                                format: 'uuid',
+                              },
+                              name: {
+                                type: 'string',
+                              },
+                              role: {
+                                type: 'string',
+                              },
+                              status: {
+                                type: 'string',
+                              },
+                            },
+                          },
+                          assigner: {
+                            type: 'object',
+                            nullable: true,
+                            description:
+                              'The agent that created or assigned this task.',
+                            properties: {
+                              id: {
+                                type: 'string',
+                                format: 'uuid',
+                              },
+                              name: {
+                                type: 'string',
+                              },
+                              role: {
+                                type: 'string',
+                              },
+                              status: {
+                                type: 'string',
+                              },
+                            },
+                          },
+                          subtasks: {
+                            type: 'array',
+                            description:
+                              'Direct child tasks of this task.',
+                            items: {
+                              $ref: '#/components/schemas/Task',
+                            },
+                          },
+                          dependencies: {
+                            type: 'array',
+                            description:
+                              'Tasks that this task depends on.',
+                            items: {
+                              type: 'object',
+                              properties: {
+                                id: {
+                                  type: 'string',
+                                  format: 'uuid',
+                                },
+                                depends_on_task_id: {
+                                  type: 'string',
+                                  format: 'uuid',
+                                },
+                                dependency_type: {
+                                  type: 'string',
+                                  enum: [
+                                    'blocks',
+                                    'requires',
+                                    'optional',
+                                  ],
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Task not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    patch: {
+      tags: ['Tasks'],
+      operationId: 'updateTask',
+      summary: 'Update task',
+      description: 'Update an existing task with partial data.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'Unique identifier of the task.',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/UpdateTaskInput',
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Task updated successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    $ref: '#/components/schemas/Task',
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid request body.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Task not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    delete: {
+      tags: ['Tasks'],
+      operationId: 'deleteTask',
+      summary: 'Delete task',
+      description:
+        'Delete a task by ID. Returns confirmation of the deletion.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'Unique identifier of the task.',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Task deleted successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    type: 'object',
+                    required: ['id', 'deleted'],
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description:
+                          'Unique identifier of the deleted task.',
+                      },
+                      deleted: {
+                        type: 'boolean',
+                        enum: [true],
+                        description:
+                          'Confirmation that the task was deleted.',
+                      },
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Task not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/tasks/batch': {
+    post: {
+      tags: ['Tasks'],
+      operationId: 'batchTaskOperations',
+      summary: 'Batch operations',
+      description:
+        'Perform batch create, update, or delete operations on tasks. Supports up to 100 tasks per request.',
+      security: [{ BearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              oneOf: [
+                {
+                  type: 'object',
+                  title: 'Batch Create',
+                  description:
+                    'Create multiple tasks in a single request.',
+                  required: ['tasks'],
+                  properties: {
+                    tasks: {
+                      type: 'array',
+                      description:
+                        'Array of task creation inputs.',
+                      minItems: 1,
+                      maxItems: 100,
+                      items: {
+                        $ref: '#/components/schemas/CreateTaskInput',
+                      },
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  title: 'Batch Update',
+                  description:
+                    'Update multiple tasks in a single request.',
+                  required: ['tasks'],
+                  properties: {
+                    tasks: {
+                      type: 'array',
+                      description:
+                        'Array of task update objects containing the task ID and update data.',
+                      minItems: 1,
+                      maxItems: 100,
+                      items: {
+                        type: 'object',
+                        required: ['id', 'data'],
+                        properties: {
+                          id: {
+                            type: 'string',
+                            format: 'uuid',
+                            description:
+                              'Unique identifier of the task to update.',
+                          },
+                          data: {
+                            $ref: '#/components/schemas/UpdateTaskInput',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  title: 'Batch Delete',
+                  description:
+                    'Delete multiple tasks in a single request.',
+                  required: ['ids'],
+                  properties: {
+                    ids: {
+                      type: 'array',
+                      description:
+                        'Array of task IDs to delete.',
+                      minItems: 1,
+                      maxItems: 100,
+                      items: {
+                        type: 'string',
+                        format: 'uuid',
+                      },
+                    },
+                    force: {
+                      type: 'boolean',
+                      description:
+                        'Force deletion even if tasks have active subtasks or dependencies.',
+                      default: false,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Batch operation completed successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    oneOf: [
+                      {
+                        type: 'object',
+                        title: 'Batch Create Result',
+                        required: ['created'],
+                        properties: {
+                          created: {
+                            type: 'array',
+                            items: {
+                              $ref: '#/components/schemas/Task',
+                            },
+                          },
+                        },
+                      },
+                      {
+                        type: 'object',
+                        title: 'Batch Update Result',
+                        required: ['updated'],
+                        properties: {
+                          updated: {
+                            type: 'array',
+                            items: {
+                              $ref: '#/components/schemas/Task',
+                            },
+                          },
+                        },
+                      },
+                      {
+                        type: 'object',
+                        title: 'Batch Delete Result',
+                        required: ['deleted'],
+                        properties: {
+                          deleted: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              required: ['id', 'deleted'],
+                              properties: {
+                                id: {
+                                  type: 'string',
+                                  format: 'uuid',
+                                },
+                                deleted: {
+                                  type: 'boolean',
+                                  enum: [true],
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Invalid request body or batch size exceeds the maximum of 100.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/tasks/tree': {
+    get: {
+      tags: ['Tasks'],
+      operationId: 'getTaskTree',
+      summary: 'Get task hierarchy tree',
+      description:
+        'Retrieve the hierarchical tree of tasks starting from a root task, with configurable depth and filtering options.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'root_id',
+          in: 'query',
+          description: 'UUID of the root task for the tree.',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+        {
+          name: 'max_depth',
+          in: 'query',
+          description:
+            'Maximum depth of the tree to traverse.',
+          required: false,
+          schema: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 10,
+            default: 10,
+          },
+        },
+        {
+          name: 'include_completed',
+          in: 'query',
+          description:
+            'Whether to include completed tasks in the tree.',
+          required: false,
+          schema: {
+            type: 'boolean',
+            default: true,
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description:
+            'Hierarchical tree of tasks rooted at the specified task.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    type: 'object',
+                    description:
+                      'A task tree node containing the task data and its children recursively.',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                      },
+                      title: {
+                        type: 'string',
+                      },
+                      status: {
+                        type: 'string',
+                        enum: [
+                          'queued',
+                          'in_progress',
+                          'blocked',
+                          'review',
+                          'completed',
+                          'failed',
+                          'cancelled',
+                        ],
+                      },
+                      priority: {
+                        type: 'string',
+                        enum: ['low', 'normal', 'high', 'urgent'],
+                      },
+                      assignee_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        nullable: true,
+                      },
+                      progress_percent: {
+                        type: 'integer',
+                        minimum: 0,
+                        maximum: 100,
+                      },
+                      depth: {
+                        type: 'integer',
+                        description:
+                          'Depth of this node relative to the root.',
+                      },
+                      children: {
+                        type: 'array',
+                        description:
+                          'Child task tree nodes.',
+                        items: {
+                          type: 'object',
+                          description:
+                            'Recursive task tree node (same structure as parent).',
+                        },
+                      },
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid query parameters.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Root task not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  '/tasks/{id}/dependencies': {
+    get: {
+      tags: ['Tasks'],
+      operationId: 'getTaskDependencies',
+      summary: 'Get task dependencies',
+      description:
+        'Retrieve all dependencies for a specific task, split into tasks it depends on and tasks it blocks.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'Unique identifier of the task.',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Task dependencies retrieved successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    type: 'object',
+                    required: ['depends_on', 'blocked_by'],
+                    properties: {
+                      depends_on: {
+                        type: 'array',
+                        description:
+                          'Tasks that this task depends on (must complete before this task can proceed).',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Dependency record ID.',
+                            },
+                            task_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'The current task ID.',
+                            },
+                            depends_on_task_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'The task that must complete first.',
+                            },
+                            dependency_type: {
+                              type: 'string',
+                              enum: [
+                                'blocks',
+                                'requires',
+                                'optional',
+                              ],
+                            },
+                            task: {
+                              $ref: '#/components/schemas/Task',
+                            },
+                          },
+                        },
+                      },
+                      blocked_by: {
+                        type: 'array',
+                        description:
+                          'Tasks that are blocked by this task (waiting for this task to complete).',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'Dependency record ID.',
+                            },
+                            task_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'The task that is blocked.',
+                            },
+                            depends_on_task_id: {
+                              type: 'string',
+                              format: 'uuid',
+                              description:
+                                'The current task ID.',
+                            },
+                            dependency_type: {
+                              type: 'string',
+                              enum: [
+                                'blocks',
+                                'requires',
+                                'optional',
+                              ],
+                            },
+                            task: {
+                              $ref: '#/components/schemas/Task',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Task not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+    post: {
+      tags: ['Tasks'],
+      operationId: 'addTaskDependency',
+      summary: 'Add task dependency',
+      description:
+        'Add a dependency relationship between two tasks.',
+      security: [{ BearerAuth: [] }],
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'Unique identifier of the task to add the dependency to.',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid',
+          },
+        },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['depends_on_task_id', 'dependency_type'],
+              properties: {
+                depends_on_task_id: {
+                  type: 'string',
+                  format: 'uuid',
+                  description:
+                    'UUID of the task that this task depends on.',
+                },
+                dependency_type: {
+                  type: 'string',
+                  enum: ['blocks', 'requires', 'optional'],
+                  description:
+                    'Type of dependency relationship. "blocks" means the dependency must complete before this task can start. "requires" means the dependency output is needed. "optional" means the dependency is informational.',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Task dependency created successfully.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['data', 'meta'],
+                properties: {
+                  data: {
+                    type: 'object',
+                    description: 'The created task dependency record.',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'Unique identifier of the dependency.',
+                      },
+                      task_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The task that has the dependency.',
+                      },
+                      depends_on_task_id: {
+                        type: 'string',
+                        format: 'uuid',
+                        description: 'The task that is depended upon.',
+                      },
+                      dependency_type: {
+                        type: 'string',
+                        enum: ['blocks', 'requires', 'optional'],
+                      },
+                      created_at: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                  },
+                  meta: {
+                    type: 'object',
+                    required: ['timestamp'],
+                    properties: {
+                      timestamp: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'Server timestamp of the response.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description:
+            'Invalid request body or circular dependency detected.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Authentication required.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Task or dependency target not found.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+        '409': {
+          description: 'Dependency already exists between these tasks.',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/ErrorResponse',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -1,14 +1,12 @@
-import { createSwaggerSpec } from 'next-swagger-doc';
+import { allPaths } from './openapi';
 
 export const getApiDocs = async () => {
-  const spec = createSwaggerSpec({
-    apiFolder: 'src/app/api',
-    definition: {
+  const spec = {
       openapi: '3.0.0',
       info: {
         title: 'ARM API - Agent Relationship Management',
         version: '1.0.0',
-        description: 'REST API for managing AI agents, tasks, decisions, escalations, and messages in the ARM platform.',
+        description: 'REST API for managing AI agents, tasks, decisions, escalations, and messages in the Pink Beam ARM platform. All endpoints require JWT authentication via Supabase Auth unless otherwise noted.',
         contact: {
           name: 'Pink Beam',
           url: 'https://pinkbeam.ai',
@@ -21,14 +19,18 @@ export const getApiDocs = async () => {
         },
       ],
       tags: [
-        { name: 'Agents', description: 'Agent management and configuration' },
-        { name: 'Tasks', description: 'Task creation, assignment, and tracking' },
-        { name: 'Decisions', description: 'Decision proposal and approval workflow' },
-        { name: 'Escalations', description: 'Escalation handling and resolution' },
-        { name: 'Messages', description: 'Inter-agent messaging system' },
-        { name: 'Activities', description: 'Activity feed and logging' },
-        { name: 'Analytics', description: 'Analytics and reporting' },
+        { name: 'Agents', description: 'Agent management, configuration, and version history' },
+        { name: 'Tasks', description: 'Task creation, assignment, tracking, batch operations, and dependency management' },
+        { name: 'Decisions', description: 'Decision proposal, approval workflow, and audit trail' },
+        { name: 'Escalations', description: 'Escalation handling, resolution, and statistics' },
+        { name: 'Messages', description: 'Inter-agent messaging protocol (AAP)' },
+        { name: 'Activities', description: 'Activity feed and event logging' },
+        { name: 'Chats', description: 'User-agent chat conversations' },
+        { name: 'Agent Templates', description: 'Reusable agent configuration templates' },
+        { name: 'Analytics', description: 'Dashboard metrics, agent performance, leaderboards, and ROI analysis' },
+        { name: 'Meta-Agent', description: 'VALIS natural language command interface for CEO operations' },
       ],
+      paths: allPaths,
       components: {
         securitySchemes: {
           BearerAuth: {
@@ -572,6 +574,46 @@ export const getApiDocs = async () => {
             },
             required: ['page', 'limit', 'total', 'totalPages'],
           },
+          // Agent Config Schemas
+          AgentConfig: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', format: 'uuid' },
+              agent_id: { type: 'string', format: 'uuid' },
+              version: { type: 'integer' },
+              config: { type: 'object', additionalProperties: true },
+              created_at: { type: 'string', format: 'date-time' },
+              updated_at: { type: 'string', format: 'date-time' },
+            },
+            required: ['id', 'agent_id', 'version', 'config'],
+          },
+          UpdateAgentConfigInput: {
+            type: 'object',
+            properties: {
+              config: { type: 'object', additionalProperties: true },
+              change_note: { type: 'string' },
+            },
+          },
+          TestAgentConfigInput: {
+            type: 'object',
+            properties: {
+              config: { type: 'object', additionalProperties: true },
+            },
+            required: ['config'],
+          },
+          ConfigVersion: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', format: 'uuid' },
+              agent_id: { type: 'string', format: 'uuid' },
+              version: { type: 'integer' },
+              config: { type: 'object', additionalProperties: true },
+              change_note: { type: 'string', nullable: true },
+              created_by: { type: 'string', format: 'uuid', nullable: true },
+              created_at: { type: 'string', format: 'date-time' },
+            },
+            required: ['id', 'agent_id', 'version', 'config', 'created_at'],
+          },
         },
       },
       security: [
@@ -579,7 +621,6 @@ export const getApiDocs = async () => {
           BearerAuth: [],
         },
       ],
-    },
-  });
+  };
   return spec;
 };


### PR DESCRIPTION
## Summary

- Complete OpenAPI 3.0 specification covering all 41 ARM API endpoints across 10 feature areas
- Swagger UI available at `/api-docs` for interactive testing
- Spec served at `/api/docs/spec` as JSON
- All endpoints documented with params, request bodies, response schemas, auth requirements, and error codes

### Endpoints Documented

| Area | Endpoints | Highlights |
|------|-----------|-----------|
| Agents | 10 | CRUD, config versioning, restore, test |
| Tasks | 9 | CRUD, batch (100 items), tree hierarchy, dependencies |
| Decisions | 6 | CRUD, context, stats |
| Escalations | 6 | CRUD, resolve, stats |
| Messages | 5 | Send, read/ack, threads |
| Activities | 1 | Cursor-based feed with filtering |
| Chats | 6 | User-agent conversations |
| Agent Templates | 5 | System + custom templates |
| Analytics | 5 | Overview, agent perf, leaderboard, bottlenecks, ROI |
| Meta-Agent | 4 | VALIS natural language interface |

### Architecture

- `src/lib/openapi/` — Path definitions split by domain (agents, tasks, decisions-escalations, messages-activities)
- `src/lib/openapi/index.ts` — Merges all paths
- `src/lib/swagger.ts` — Complete spec with component schemas + merged paths
- Existing Swagger UI at `/api-docs` and spec endpoint at `/api/docs/spec` remain unchanged

## Test plan

- [ ] Navigate to `/api-docs` and verify Swagger UI loads with all endpoints
- [ ] Expand each tag group and verify operations are documented
- [ ] Verify `/api/docs/spec` returns valid JSON
- [ ] Spot-check a few endpoints match actual route handler behavior

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)