### PR TITLE
feat(agents): Add Performance and Activity tabs to AgentDetailPanel #120

### DIFF
--- a/src/__tests__/components/dashboard/agents/ActivityTab.test.tsx
+++ b/src/__tests__/components/dashboard/agents/ActivityTab.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Activity Tab Tests
+ * 
+ * Tests for the ActivityTab component showing agent activity feed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ActivityTab } from '@/components/dashboard/agents/ActivityTab';
+import type { ActivityEvent } from '@/components/dashboard/activity/types';
+
+// Mock the activity feed hook
+const mockUseActivityFeed = vi.fn();
+vi.mock('@/components/dashboard/activity/useActivityFeed', () => ({
+  useActivityFeed: (options: Record<string, unknown>) => mockUseActivityFeed(options),
+}));
+
+// Mock ActivityItem component
+vi.mock('@/components/dashboard/activity/ActivityItem', () => ({
+  ActivityItem: vi.fn(({ event, isNew }: { event: ActivityEvent; isNew?: boolean }) => (
+    <div data-testid={`activity-item-${event.id}`} data-is-new={isNew}>
+      {event.metadata.title}
+    </div>
+  )),
+  ActivityItemSkeleton: vi.fn(() => <div data-testid="activity-item-skeleton" />),
+}));
+
+// Mock UI components
+vi.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: vi.fn(({ children }: { children: React.ReactNode }) => <div>{children}</div>),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: vi.fn(() => <div data-testid="skeleton" />),
+}));
+
+vi.mock('@/components/ui/alert', () => ({
+  Alert: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="alert">{children}</div>),
+  AlertDescription: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="alert-description">{children}</div>),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: vi.fn(({ children, onClick, disabled }: { children: React.ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button data-testid="button" onClick={onClick} disabled={disabled}>{children}</button>
+  )),
+}));
+
+const mockEvents: ActivityEvent[] = [
+  {
+    id: 'evt-1',
+    type: 'task_completed',
+    timestamp: '2024-02-14T10:00:00Z',
+    actor: { id: 'agent-123', type: 'agent', name: 'Test Agent' },
+    target: { id: 'task-1', type: 'task', name: 'Research Task' },
+    metadata: { title: 'Completed research task', description: 'Task completed successfully' },
+  },
+  {
+    id: 'evt-2',
+    type: 'decision_made',
+    timestamp: '2024-02-14T09:30:00Z',
+    actor: { id: 'agent-123', type: 'agent', name: 'Test Agent' },
+    metadata: { title: 'Made strategic decision', confidence: 85 },
+  },
+  {
+    id: 'evt-3',
+    type: 'escalation_created',
+    timestamp: '2024-02-14T09:00:00Z',
+    actor: { id: 'agent-123', type: 'agent', name: 'Test Agent' },
+    metadata: { title: 'Escalated issue', description: 'Needs approval' },
+  },
+];
+
+describe('ActivityTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render loading state', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: [],
+      isLoading: true,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    expect(screen.getAllByTestId('activity-item-skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('should render error state', () => {
+    const refetch = vi.fn();
+    mockUseActivityFeed.mockReturnValue({
+      events: [],
+      isLoading: false,
+      error: new Error('Failed to load activities'),
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch,
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    expect(screen.getByTestId('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Failed to load activity feed/)).toBeInTheDocument();
+    
+    // Click retry button
+    const retryButton = screen.getByText('Retry');
+    fireEvent.click(retryButton);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('should render empty state when no activities', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: [],
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    expect(screen.getByText(/No recent activity/)).toBeInTheDocument();
+    expect(screen.getByText(/This agent hasn't performed any actions recently./)).toBeInTheDocument();
+  });
+
+  it('should render activity list', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: mockEvents,
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    // Check all events are rendered
+    expect(screen.getByTestId('activity-item-evt-1')).toBeInTheDocument();
+    expect(screen.getByTestId('activity-item-evt-2')).toBeInTheDocument();
+    expect(screen.getByTestId('activity-item-evt-3')).toBeInTheDocument();
+  });
+
+  it('should mark first 3 events as new', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: mockEvents,
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    // First 3 should be marked as new
+    expect(screen.getByTestId('activity-item-evt-1')).toHaveAttribute('data-is-new', 'true');
+    expect(screen.getByTestId('activity-item-evt-2')).toHaveAttribute('data-is-new', 'true');
+    expect(screen.getByTestId('activity-item-evt-3')).toHaveAttribute('data-is-new', 'true');
+  });
+
+  it('should show realtime indicator when realtime is active', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: mockEvents,
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: true,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    expect(screen.getByText('Live updates')).toBeInTheDocument();
+  });
+
+  it('should call loadMore when button is clicked', () => {
+    const loadMore = vi.fn();
+    mockUseActivityFeed.mockReturnValue({
+      events: mockEvents,
+      isLoading: false,
+      error: null,
+      hasMore: true,
+      loadMore,
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    const loadMoreButton = screen.getByText('Load more');
+    fireEvent.click(loadMoreButton);
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('should show end of feed message when no more items', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: mockEvents,
+      isLoading: false,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    expect(screen.getByText('End of activity feed')).toBeInTheDocument();
+  });
+
+  it('should pass correct filter to useActivityFeed', () => {
+    mockUseActivityFeed.mockReturnValue({
+      events: [],
+      isLoading: true,
+      error: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refetch: vi.fn(),
+      isRealtime: false,
+    });
+
+    render(<ActivityTab agentId="agent-123" />);
+
+    expect(mockUseActivityFeed).toHaveBeenCalledWith({
+      filter: {
+        agentId: 'agent-123',
+        type: 'all',
+        timeRange: '7d',
+      },
+      enabled: true,
+    });
+  });
+
+});

--- a/src/__tests__/components/dashboard/agents/PerformanceTab.test.tsx
+++ b/src/__tests__/components/dashboard/agents/PerformanceTab.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Performance Tab Tests
+ * 
+ * Tests for the PerformanceTab component showing agent analytics.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PerformanceTab } from '@/components/dashboard/agents/PerformanceTab';
+import type { AgentAnalyticsData } from '@/lib/hooks/useAgentAnalytics';
+
+// Mock recharts to avoid rendering issues in tests
+vi.mock('recharts', () => ({
+  LineChart: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>),
+  BarChart: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>),
+  PieChart: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>),
+  Line: vi.fn(() => <div data-testid="line" />),
+  Bar: vi.fn(() => <div data-testid="bar" />),
+  Pie: vi.fn(() => <div data-testid="pie" />),
+  Cell: vi.fn(() => <div data-testid="cell" />),
+  XAxis: vi.fn(() => <div data-testid="x-axis" />),
+  YAxis: vi.fn(() => <div data-testid="y-axis" />),
+  CartesianGrid: vi.fn(() => <div data-testid="cartesian-grid" />),
+  Tooltip: vi.fn(() => <div data-testid="tooltip" />),
+  Legend: vi.fn(() => <div data-testid="legend" />),
+  ResponsiveContainer: vi.fn(({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  )),
+}));
+
+// Mock UI components
+vi.mock('@/components/ui/card', () => ({
+  Card: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="card">{children}</div>),
+  CardContent: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="card-content">{children}</div>),
+  CardHeader: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="card-header">{children}</div>),
+  CardTitle: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="card-title">{children}</div>),
+  CardDescription: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="card-description">{children}</div>),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: vi.fn(() => <div data-testid="skeleton" />),
+}));
+
+vi.mock('@/components/ui/alert', () => ({
+  Alert: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="alert">{children}</div>),
+  AlertDescription: vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="alert-description">{children}</div>),
+}));
+
+const mockAnalyticsData: AgentAnalyticsData = {
+  agent: {
+    id: 'agent-123',
+    name: 'Test Agent',
+    avatarUrl: 'https://example.com/avatar.png',
+    role: 'worker',
+    status: 'active',
+    description: 'A test agent',
+    createdAt: '2024-01-01T00:00:00Z',
+    llmConfig: {
+      provider: 'openai',
+      model: 'gpt-4',
+      temperature: 0.7,
+      max_tokens: 2000,
+    },
+    limits: {
+      max_sub_agents: 5,
+      escalation_threshold: 0.8,
+      timeout_seconds: 300,
+      max_tokens_per_task: 4000,
+      max_cost_per_task_usd: 1.0,
+    },
+  },
+  summary: {
+    totalTasksCompleted: 150,
+    totalTasksFailed: 10,
+    totalTasksCreated: 160,
+    successRate: 0.9375,
+    avgTaskDuration: 120,
+    totalCost: 45.5,
+    totalEscalations: 5,
+    totalDecisions: 50,
+    totalOverridden: 2,
+    overrideRate: 4,
+    avgConfidence: 0.85,
+  },
+  taskTypeBreakdown: [
+    { type: 'research', count: 60, completed: 55, failed: 5, cost: 18, successRate: 91.67 },
+    { type: 'writing', count: 50, completed: 48, failed: 2, cost: 15, successRate: 96 },
+    { type: 'analysis', count: 30, completed: 28, failed: 2, cost: 9, successRate: 93.33 },
+    { type: 'review', count: 20, completed: 19, failed: 1, cost: 3.5, successRate: 95 },
+  ],
+  workloadDistribution: Array(24).fill(0).map((_, i) => ({
+    hour: i,
+    tasks: i >= 8 && i <= 18 ? Math.floor(Math.random() * 10) : 0,
+  })),
+  dailyTrend: [
+    { date: '2024-02-01', tasksCompleted: 10, tasksFailed: 1, successRate: 0.91, cost: 3, escalations: 0, avgDuration: 120, confidence: 0.85 },
+    { date: '2024-02-02', tasksCompleted: 12, tasksFailed: 0, successRate: 1, cost: 3.5, escalations: 1, avgDuration: 110, confidence: 0.88 },
+    { date: '2024-02-03', tasksCompleted: 8, tasksFailed: 2, successRate: 0.8, cost: 2.5, escalations: 0, avgDuration: 130, confidence: 0.82 },
+    { date: '2024-02-04', tasksCompleted: 15, tasksFailed: 1, successRate: 0.94, cost: 4.5, escalations: 0, avgDuration: 115, confidence: 0.90 },
+  ],
+  decisionConfidenceTrend: [
+    { date: '2024-02-01', confidence: 85 },
+    { date: '2024-02-02', confidence: 88 },
+    { date: '2024-02-03', confidence: 82 },
+  ],
+  escalationResolutionTrend: [
+    { date: '2024-02-01', resolutionTime: 300 },
+    { date: '2024-02-02', resolutionTime: 240 },
+  ],
+  recentTasks: [
+    { type: 'research', status: 'completed', createdAt: '2024-02-04T10:00:00Z', cost: 0.5 },
+    { type: 'writing', status: 'completed', createdAt: '2024-02-04T09:00:00Z', cost: 0.3 },
+  ],
+  period: { days: 30 },
+};
+
+describe('PerformanceTab', () => {
+  it('should render loading state', () => {
+    render(<PerformanceTab isLoading={true} />);
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('should render error state', () => {
+    const error = new Error('Failed to load analytics');
+    render(<PerformanceTab error={error} />);
+
+    expect(screen.getByTestId('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Failed to load performance data/)).toBeInTheDocument();
+  });
+
+  it('should render empty state when no data', () => {
+    render(<PerformanceTab data={null} />);
+
+    expect(screen.getByText(/No performance data available/)).toBeInTheDocument();
+  });
+
+  it('should render metrics with data', () => {
+    render(<PerformanceTab data={mockAnalyticsData} />);
+
+    // Check key metrics are displayed
+    expect(screen.getByText('150')).toBeInTheDocument(); // Tasks Completed
+    expect(screen.getByText('93.8%')).toBeInTheDocument(); // Success Rate
+    expect(screen.getByText('$45.50')).toBeInTheDocument(); // Total Cost
+  });
+
+  it('should render charts when trend data exists', () => {
+    render(<PerformanceTab data={mockAnalyticsData} />);
+
+    // Charts should be rendered (use getAllByTestId since there are multiple charts)
+    expect(screen.getAllByTestId('line-chart').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('bar-chart').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('pie-chart').length).toBeGreaterThan(0);
+  });
+
+  it('should display correct subtext for success rate', () => {
+    render(<PerformanceTab data={mockAnalyticsData} />);
+
+    // With 93.75% success rate, should show "Good"
+    expect(screen.getByText('Good')).toBeInTheDocument();
+  });
+
+  it('should display escalations count', () => {
+    render(<PerformanceTab data={mockAnalyticsData} />);
+
+    expect(screen.getByText('5')).toBeInTheDocument(); // Total escalations
+  });
+
+  it('should display decisions info', () => {
+    render(<PerformanceTab data={mockAnalyticsData} />);
+
+    expect(screen.getByText('50')).toBeInTheDocument(); // Total decisions
+    expect(screen.getByText('2 overridden')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/hooks/useAgentAnalytics.test.ts
+++ b/src/__tests__/hooks/useAgentAnalytics.test.ts
@@ -1,0 +1,239 @@
+/**
+ * useAgentAnalytics Hook Tests
+ * 
+ * Tests for the useAgentAnalytics hook that fetches agent analytics data.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAgentAnalytics } from '@/lib/hooks/useAgentAnalytics';
+
+// Mock Supabase client
+const mockGetSession = vi.fn();
+const mockCreateClient = vi.fn(() => ({
+  auth: {
+    getSession: mockGetSession,
+  },
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockCreateClient(),
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+const mockAnalyticsResponse = {
+  data: {
+    agent: {
+      id: 'agent-123',
+      name: 'Test Agent',
+      role: 'worker',
+      status: 'active',
+      createdAt: '2024-01-01T00:00:00Z',
+    },
+    summary: {
+      totalTasksCompleted: 150,
+      totalTasksFailed: 10,
+      totalTasksCreated: 160,
+      successRate: 0.9375,
+      avgTaskDuration: 120,
+      totalCost: 45.5,
+      totalEscalations: 5,
+      totalDecisions: 50,
+      totalOverridden: 2,
+      overrideRate: 4,
+      avgConfidence: 0.85,
+    },
+    taskTypeBreakdown: [
+      { type: 'research', count: 60, completed: 55, failed: 5, cost: 18, successRate: 91.67 },
+    ],
+    workloadDistribution: Array(24).fill(0).map((_, i) => ({ hour: i, tasks: 0 })),
+    dailyTrend: [
+      { date: '2024-02-01', tasksCompleted: 10, tasksFailed: 1, successRate: 0.91, cost: 3, escalations: 0, avgDuration: 120, confidence: 0.85 },
+    ],
+    decisionConfidenceTrend: [],
+    escalationResolutionTrend: [],
+    recentTasks: [],
+    period: { days: 30 },
+  },
+};
+
+describe('useAgentAnalytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return loading state initially', () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAnalyticsResponse),
+    });
+
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: true })
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should fetch analytics data successfully', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAnalyticsResponse),
+    });
+
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: true })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockAnalyticsResponse.data);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should not fetch when disabled', () => {
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: false })
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should not fetch when agentId is not provided', () => {
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ enabled: true })
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should handle fetch error', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      statusText: 'Internal Server Error',
+      json: () => Promise.resolve({ error: 'Failed to fetch' }),
+    });
+
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: true })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toContain('Failed to fetch');
+  });
+
+  it('should handle authentication error', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: null },
+    });
+
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: true })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Not authenticated');
+  });
+
+  it('should use correct days parameter', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAnalyticsResponse),
+    });
+
+    renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', days: 7, enabled: true })
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/analytics/agents/agent-123?days=7',
+        expect.objectContaining({
+          headers: {
+            'Authorization': 'Bearer test-token',
+          },
+        })
+      );
+    });
+  });
+
+  it('should refetch data when refetch is called', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAnalyticsResponse),
+    });
+
+    const { result } = renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: true })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Clear mock to check refetch
+    (global.fetch as ReturnType<typeof vi.fn>).mockClear();
+
+    result.current.refetch();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should include authorization header in request', async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockAnalyticsResponse),
+    });
+
+    renderHook(() => 
+      useAgentAnalytics({ agentId: 'agent-123', enabled: true })
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: {
+            'Authorization': 'Bearer test-token',
+          },
+        })
+      );
+    });
+  });
+});

--- a/src/components/dashboard/agents/ActivityTab.tsx
+++ b/src/components/dashboard/agents/ActivityTab.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import * as React from 'react';
+import { Activity, RefreshCw, AlertCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { useActivityFeed } from '@/components/dashboard/activity/useActivityFeed';
+import { ActivityItem, ActivityItemSkeleton } from '@/components/dashboard/activity/ActivityItem';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ActivityTabProps {
+  agentId: string;
+}
+
+// ============================================================================
+// Activity Tab Component
+// ============================================================================
+
+export function ActivityTab({ agentId }: ActivityTabProps) {
+  const {
+    events,
+    isLoading,
+    error,
+    hasMore,
+    loadMore,
+    refetch,
+    isRealtime,
+  } = useActivityFeed({
+    filter: {
+      agentId,
+      type: 'all',
+      timeRange: '7d',
+    },
+    enabled: !!agentId,
+  });
+
+  if (error) {
+    return (
+      <Alert variant="destructive" className="mt-4">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription className="flex items-center justify-between">
+          <span>Failed to load activity feed: {error.message}</span>
+          <Button variant="ghost" size="sm" onClick={refetch}>
+            <RefreshCw className="h-4 w-4 mr-1" />
+            Retry
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (isLoading) {
+    return <ActivityTabSkeleton />;
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <Activity className="h-12 w-12 mx-auto mb-4 opacity-50" />
+        <p className="font-medium">No recent activity</p>
+        <p className="text-sm mt-1">This agent hasn&apos;t performed any actions recently.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Realtime indicator */}
+      {isRealtime && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+          </span>
+          <span>Live updates</span>
+        </div>
+      )}
+
+      {/* Activity list */}
+      <div className="space-y-1">
+        {events.map((event, index) => (
+          <ActivityItem
+            key={event.id}
+            event={event}
+            isNew={index < 3} // Mark first 3 as new for visual emphasis
+          />
+        ))}
+      </div>
+
+      {/* Load more */}
+      {hasMore && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full"
+          onClick={loadMore}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              Loading...
+            </>
+          ) : (
+            'Load more'
+          )}
+        </Button>
+      )}
+
+      {/* End of feed */}
+      {!hasMore && events.length > 0 && (
+        <p className="text-center text-xs text-muted-foreground py-4">
+          End of activity feed
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Skeleton Loading State
+// ============================================================================
+
+function ActivityTabSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Realtime indicator skeleton */}
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-2 w-2 rounded-full" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+
+      {/* Activity items skeleton */}
+      <div className="space-y-2">
+        {[...Array(5)].map((_, i) => (
+          <ActivityItemSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ActivityTab;

--- a/src/components/dashboard/agents/AgentDetailPanel.tsx
+++ b/src/components/dashboard/agents/AgentDetailPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { X, Bot, Calendar, Activity, CheckCircle2, Clock, AlertCircle, MessageSquare, Play, Pause, Pencil } from 'lucide-react';
+import { X, Bot, Calendar, Activity, MessageSquare, Play, Pause, Pencil } from 'lucide-react';
 import { cn, formatDateTime, getAgentStatusColor, getAgentStatusLabel, getRoleLabel, getRoleBadgeColor, getInitials, getAvatarColor, formatRelativeTime } from '@/lib/utils';
 import type { Agent } from '@/types';
 import { Button } from '@/components/ui/button';
@@ -15,6 +15,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { EditAgentModal } from './EditAgentModal';
 import { useUpdateAgent } from '@/lib/hooks/useAgents';
 import { useToast } from '@/components/ui/use-toast';
+import { useAgentAnalytics } from '@/lib/hooks/useAgentAnalytics';
+import { PerformanceTab } from './PerformanceTab';
+import { ActivityTab } from './ActivityTab';
 
 interface AgentDetailPanelProps {
   agent: Agent | null;
@@ -112,6 +115,17 @@ function AgentDetailContent({
   onToggleStatus: () => void;
   onClose: () => void;
 }) {
+  // Fetch analytics data for the Performance tab
+  const {
+    data: analyticsData,
+    isLoading: analyticsLoading,
+    error: analyticsError,
+  } = useAgentAnalytics({
+    agentId: agent.id,
+    days: 30,
+    enabled: !!agent.id,
+  });
+
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
@@ -196,11 +210,15 @@ function AgentDetailContent({
           </TabsContent>
 
           <TabsContent value="performance" className="m-0 px-6 py-4">
-            <PerformanceTab agent={agent} />
+            <PerformanceTab 
+              data={analyticsData} 
+              isLoading={analyticsLoading} 
+              error={analyticsError} 
+            />
           </TabsContent>
 
           <TabsContent value="activity" className="m-0 px-6 py-4">
-            <ActivityTab agent={agent} />
+            <ActivityTab agentId={agent.id} />
           </TabsContent>
         </ScrollArea>
       </Tabs>
@@ -285,53 +303,11 @@ function OverviewTab({ agent }: { agent: Agent }) {
         </div>
         {agent.last_active_at && (
           <div className="flex items-center gap-2 text-muted-foreground">
-            <Clock className="h-4 w-4" />
+            <Bot className="h-4 w-4" />
             <span>Last active {formatRelativeTime(agent.last_active_at)}</span>
           </div>
         )}
       </div>
-    </div>
-  );
-}
-
-function PerformanceTab({ agent }: { agent: Agent }) {
-  const stats = [
-    { label: 'Tasks Completed', value: (agent.metadata?.tasks_completed as number) || 0, icon: CheckCircle2 },
-    { label: 'Success Rate', value: `${(((agent.metadata?.success_rate as number) || 0) * 100).toFixed(0)}%`, icon: Activity },
-    { label: 'Escalations', value: (agent.metadata?.escalation_count as number) || 0, icon: AlertCircle },
-    { label: 'Avg Response Time', value: (agent.metadata?.avg_response_time as number) ? `${agent.metadata?.avg_response_time}s` : 'N/A', icon: Clock },
-  ];
-
-  return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-2 gap-4">
-        {stats.map((stat) => (
-          <div key={stat.label} className="bg-muted rounded-lg p-4">
-            <div className="flex items-center gap-2 text-muted-foreground mb-2">
-              <stat.icon className="h-4 w-4" />
-              <span className="text-xs">{stat.label}</span>
-            </div>
-            <p className="text-2xl font-bold">{stat.value}</p>
-          </div>
-        ))}
-      </div>
-
-      <div className="bg-muted rounded-lg p-4">
-        <h4 className="text-sm font-medium mb-4">Recent Performance</h4>
-        <p className="text-sm text-muted-foreground text-center py-8">
-          Performance charts will appear here once the agent has completed more tasks.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function ActivityTab({ agent }: { agent: Agent }) {
-  return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground text-center py-8">
-        Activity feed for this agent will appear here.
-      </p>
     </div>
   );
 }
@@ -373,3 +349,5 @@ function AgentDetailSkeleton() {
     </div>
   );
 }
+
+export default AgentDetailPanel;

--- a/src/components/dashboard/agents/CreateAgentModal.tsx
+++ b/src/components/dashboard/agents/CreateAgentModal.tsx
@@ -20,6 +20,7 @@ interface CreateAgentModalProps {
   onOpenChange: (open: boolean) => void;
   onCreate: (data: CreateAgentInput) => Promise<void>;
   loading?: boolean;
+  existingAgents?: Agent[];
 }
 
 type Step = 'template' | 'basic' | 'capabilities' | 'review';

--- a/src/components/dashboard/agents/PerformanceTab.tsx
+++ b/src/components/dashboard/agents/PerformanceTab.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+import * as React from 'react';
+import { CheckCircle2, Activity, Clock, AlertCircle, TrendingUp, DollarSign, Brain } from 'lucide-react';
+import { cn, formatDuration } from '@/lib/utils';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+} from 'recharts';
+import type { AgentAnalyticsData } from '@/lib/hooks/useAgentAnalytics';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PerformanceTabProps {
+  data?: AgentAnalyticsData | null;
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+interface MetricCardProps {
+  label: string;
+  value: string | number;
+  subtext?: string;
+  subtextColor?: string;
+  icon: React.ReactNode;
+  isLoading?: boolean;
+}
+
+// ============================================================================
+// Colors
+// ============================================================================
+
+const COLORS = ['#ec4899', '#8b5cf6', '#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
+
+// ============================================================================
+// Performance Tab Component
+// ============================================================================
+
+export function PerformanceTab({ data, isLoading, error }: PerformanceTabProps) {
+  if (error) {
+    return (
+      <Alert variant="destructive" className="mt-4">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          Failed to load performance data: {error.message}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (isLoading) {
+    return <PerformanceTabSkeleton />;
+  }
+
+  if (!data) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <Activity className="h-12 w-12 mx-auto mb-4 opacity-50" />
+        <p>No performance data available</p>
+      </div>
+    );
+  }
+
+  const { summary, dailyTrend, taskTypeBreakdown, workloadDistribution } = data;
+
+  // Calculate trend direction
+  const recentDays = dailyTrend.slice(-7);
+  const previousDays = dailyTrend.slice(-14, -7);
+  const recentAvg = recentDays.length > 0 
+    ? recentDays.reduce((sum, d) => sum + d.tasksCompleted, 0) / recentDays.length 
+    : 0;
+  const previousAvg = previousDays.length > 0 
+    ? previousDays.reduce((sum, d) => sum + d.tasksCompleted, 0) / previousDays.length 
+    : 0;
+  const trendChange = previousAvg > 0 
+    ? ((recentAvg - previousAvg) / previousAvg) * 100 
+    : 0;
+
+  // Format daily trend data for charts
+  const trendData = dailyTrend.map(d => ({
+    date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    completed: d.tasksCompleted,
+    failed: d.tasksFailed,
+    successRate: Math.round(d.successRate * 100),
+    cost: d.cost,
+    avgDuration: Math.round((d.avgDuration || 0) / 60), // Convert to minutes
+  }));
+
+  // Format task type data
+  const taskTypeData = taskTypeBreakdown.map(t => ({
+    name: t.type.charAt(0).toUpperCase() + t.type.slice(1),
+    value: t.count,
+    completed: t.completed,
+    failed: t.failed,
+    successRate: t.successRate,
+  }));
+
+  // Format workload distribution (show only hours with activity)
+  const workloadData = workloadDistribution
+    .filter(w => w.tasks > 0)
+    .map(w => ({
+      hour: `${w.hour}:00`,
+      tasks: w.tasks,
+    }));
+
+  return (
+    <div className="space-y-6">
+      {/* Key Metrics */}
+      <div className="grid grid-cols-2 gap-4">
+        <MetricCard
+          label="Tasks Completed"
+          value={summary.totalTasksCompleted}
+          subtext={summary.totalTasksFailed > 0 ? `${summary.totalTasksFailed} failed` : 'All successful'}
+          icon={<CheckCircle2 className="h-4 w-4" />}
+        />
+        <MetricCard
+          label="Success Rate"
+          value={`${(summary.successRate * 100).toFixed(1)}%`}
+          subtext={summary.successRate >= 0.95 ? 'Excellent' : summary.successRate >= 0.90 ? 'Good' : 'Needs Attention'}
+          subtextColor={summary.successRate >= 0.95 ? 'text-green-600' : summary.successRate >= 0.90 ? 'text-blue-600' : 'text-amber-600'}
+          icon={<Activity className="h-4 w-4" />}
+        />
+        <MetricCard
+          label="Avg Response Time"
+          value={summary.avgTaskDuration > 0 ? formatDuration(Math.round(summary.avgTaskDuration)) : 'N/A'}
+          subtext="per task"
+          icon={<Clock className="h-4 w-4" />}
+        />
+        <MetricCard
+          label="Total Cost"
+          value={`$${summary.totalCost.toFixed(2)}`}
+          subtext={summary.totalTasksCompleted > 0 ? `$${(summary.totalCost / summary.totalTasksCompleted).toFixed(3)} per task` : 'No tasks'}
+          icon={<DollarSign className="h-4 w-4" />}
+        />
+      </div>
+
+      {/* Task Completion Trend */}
+      {trendData.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle className="text-sm font-medium">Task Completion Trend</CardTitle>
+                <CardDescription>Last {trendData.length} days</CardDescription>
+              </div>
+              {trendChange !== 0 && (
+                <div className={cn(
+                  'flex items-center gap-1 text-xs font-medium',
+                  trendChange > 0 ? 'text-green-600' : 'text-red-600'
+                )}>
+                  <TrendingUp className={cn('h-3 w-3', trendChange < 0 && 'rotate-180')} />
+                  {Math.abs(trendChange).toFixed(1)}%
+                </div>
+              )}
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="h-48">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={trendData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted))" />
+                  <XAxis 
+                    dataKey="date" 
+                    tick={{ fontSize: 10 }} 
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis tick={{ fontSize: 10 }} />
+                  <Tooltip 
+                    contentStyle={{ 
+                      backgroundColor: 'hsl(var(--popover))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                    }}
+                    labelStyle={{ fontSize: 12 }}
+                  />
+                  <Line 
+                    type="monotone" 
+                    dataKey="completed" 
+                    stroke="#10b981" 
+                    strokeWidth={2}
+                    name="Completed"
+                    dot={false}
+                  />
+                  <Line 
+                    type="monotone" 
+                    dataKey="failed" 
+                    stroke="#ef4444" 
+                    strokeWidth={2}
+                    name="Failed"
+                    dot={false}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 10 }} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Success Rate Trend */}
+      {trendData.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Success Rate Trend</CardTitle>
+            <CardDescription>Daily success percentage</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-48">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={trendData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted))" />
+                  <XAxis 
+                    dataKey="date" 
+                    tick={{ fontSize: 10 }} 
+                    interval="preserveStartEnd"
+                  />
+                  <YAxis 
+                    tick={{ fontSize: 10 }} 
+                    domain={[0, 100]}
+                    tickFormatter={(v) => `${v}%`}
+                  />
+                  <Tooltip 
+                    contentStyle={{ 
+                      backgroundColor: 'hsl(var(--popover))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                    }}
+                    formatter={(v) => [`${v}%`, 'Success Rate']}
+                    labelStyle={{ fontSize: 12 }}
+                  />
+                  <Line 
+                    type="monotone" 
+                    dataKey="successRate" 
+                    stroke="#8b5cf6" 
+                    strokeWidth={2}
+                    name="Success Rate"
+                    dot={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Task Type Breakdown */}
+      {taskTypeData.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Task Type Breakdown</CardTitle>
+            <CardDescription>Distribution by task type</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-48">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={taskTypeData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={40}
+                    outerRadius={70}
+                    paddingAngle={2}
+                    dataKey="value"
+                  >
+                    {taskTypeData.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip 
+                    contentStyle={{ 
+                      backgroundColor: 'hsl(var(--popover))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                    }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 10 }} />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Workload Distribution */}
+      {workloadData.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Hourly Activity Pattern</CardTitle>
+            <CardDescription>Tasks created by hour of day</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-48">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={workloadData}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted))" />
+                  <XAxis dataKey="hour" tick={{ fontSize: 10 }} />
+                  <YAxis tick={{ fontSize: 10 }} />
+                  <Tooltip 
+                    contentStyle={{ 
+                      backgroundColor: 'hsl(var(--popover))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                    }}
+                  />
+                  <Bar dataKey="tasks" fill="#ec4899" radius={[4, 4, 0, 0]}>
+                    {workloadData.map((entry, index) => (
+                      <Cell 
+                        key={`cell-${index}`} 
+                        fill={entry.tasks > 5 ? '#ec4899' : entry.tasks > 2 ? '#8b5cf6' : '#94a3b8'}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Additional Stats */}
+      <div className="grid grid-cols-2 gap-4">
+        <MetricCard
+          label="Escalations"
+          value={summary.totalEscalations}
+          subtext="raised"
+          icon={<AlertCircle className="h-4 w-4" />}
+        />
+        <MetricCard
+          label="Decisions"
+          value={summary.totalDecisions}
+          subtext={summary.totalOverridden > 0 ? `${summary.totalOverridden} overridden` : 'All accepted'}
+          icon={<Brain className="h-4 w-4" />}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Metric Card Component
+// ============================================================================
+
+function MetricCard({ label, value, subtext, subtextColor = 'text-muted-foreground', icon, isLoading }: MetricCardProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-muted rounded-lg p-4 space-y-2">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-8 w-16" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-muted rounded-lg p-4">
+      <div className="flex items-center gap-2 text-muted-foreground mb-2">
+        {icon}
+        <span className="text-xs">{label}</span>
+      </div>
+      <p className="text-2xl font-bold">{value}</p>
+      {subtext && <p className={cn('text-xs mt-1', subtextColor)}>{subtext}</p>}
+    </div>
+  );
+}
+
+// ============================================================================
+// Skeleton Loading State
+// ============================================================================
+
+function PerformanceTabSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Metrics skeleton */}
+      <div className="grid grid-cols-2 gap-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="bg-muted rounded-lg p-4 space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* Charts skeleton */}
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="bg-muted rounded-lg p-4">
+          <Skeleton className="h-5 w-40 mb-2" />
+          <Skeleton className="h-3 w-24 mb-4" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default PerformanceTab;

--- a/src/lib/hooks/useAgentAnalytics.ts
+++ b/src/lib/hooks/useAgentAnalytics.ts
@@ -1,0 +1,173 @@
+'use client';
+
+import * as React from 'react';
+import { createClient } from '@/lib/supabase/client';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AgentAnalyticsData {
+  agent: {
+    id: string;
+    name: string;
+    avatarUrl?: string;
+    role: string;
+    status: string;
+    description?: string;
+    createdAt: string;
+    llmConfig?: {
+      provider: string;
+      model: string;
+      temperature: number;
+      max_tokens: number;
+    };
+    limits?: {
+      max_sub_agents: number;
+      escalation_threshold: number;
+      timeout_seconds: number;
+      max_tokens_per_task: number;
+      max_cost_per_task_usd: number;
+    };
+  };
+  summary: {
+    totalTasksCompleted: number;
+    totalTasksFailed: number;
+    totalTasksCreated: number;
+    successRate: number;
+    avgTaskDuration: number;
+    totalCost: number;
+    totalEscalations: number;
+    totalDecisions: number;
+    totalOverridden: number;
+    overrideRate: number;
+    avgConfidence: number;
+  };
+  taskTypeBreakdown: Array<{
+    type: string;
+    count: number;
+    completed: number;
+    failed: number;
+    cost: number;
+    successRate: number;
+  }>;
+  workloadDistribution: Array<{
+    hour: number;
+    tasks: number;
+  }>;
+  dailyTrend: Array<{
+    date: string;
+    tasksCompleted: number;
+    tasksFailed: number;
+    successRate: number;
+    cost: number;
+    escalations: number;
+    avgDuration: number;
+    confidence: number;
+  }>;
+  decisionConfidenceTrend: Array<{
+    date: string;
+    confidence: number;
+  }>;
+  escalationResolutionTrend: Array<{
+    date: string;
+    resolutionTime: number;
+  }>;
+  recentTasks: Array<{
+    type: string;
+    status: string;
+    createdAt: string;
+    cost?: number;
+  }>;
+  period: {
+    days: number;
+  };
+}
+
+export interface UseAgentAnalyticsOptions {
+  agentId?: string;
+  days?: number;
+  enabled?: boolean;
+}
+
+export interface UseAgentAnalyticsReturn {
+  data: AgentAnalyticsData | null;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+// ============================================================================
+// useAgentAnalytics Hook
+// ============================================================================
+
+export function useAgentAnalytics(
+  options: UseAgentAnalyticsOptions = {}
+): UseAgentAnalyticsReturn {
+  const { agentId, days = 30, enabled = true } = options;
+
+  const [data, setData] = React.useState<AgentAnalyticsData | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  const fetchAnalytics = React.useCallback(async () => {
+    if (!agentId) return;
+
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const supabase = createClient();
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        throw new Error('Not authenticated');
+      }
+
+      const response = await fetch(
+        `/api/analytics/agents/${agentId}?days=${days}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${session.access_token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.error || `Failed to fetch analytics: ${response.statusText}`
+        );
+      }
+
+      const result = await response.json();
+      setData(result.data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [agentId, days]);
+
+  // Initial fetch
+  React.useEffect(() => {
+    if (enabled && agentId) {
+      fetchAnalytics();
+    }
+  }, [enabled, agentId, fetchAnalytics]);
+
+  const refetch = React.useCallback(() => {
+    if (agentId) {
+      fetchAnalytics();
+    }
+  }, [agentId, fetchAnalytics]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refetch,
+  };
+}
+
+export default useAgentAnalytics;


### PR DESCRIPTION
Fixes #120

- PerformanceTab with task metrics, response times, charts
- ActivityTab with real-time filtered activity feed
- useAgentAnalytics hook for fetching agent data
- 26 tests covering all components