### PR TITLE
feat(db): add performance indexes for common queries (#79)

### DIFF
--- a/supabase/migrations/021_add_performance_indexes.sql
+++ b/supabase/migrations/021_add_performance_indexes.sql
@@ -1,0 +1,18 @@
+-- Migration: Add performance indexes for common query patterns
+-- Issue: #79
+-- Created: 2026-02-14
+
+-- Index for tasks assigned to specific users/agents
+CREATE INDEX IF NOT EXISTS idx_tasks_assigner ON tasks(assigner_id);
+
+-- Index for activities by agent with time-based sorting (activity feed queries)
+CREATE INDEX IF NOT EXISTS idx_activities_agent_time ON activities(agent_id, created_at DESC);
+
+-- Index for decisions filtered by agent and status (decision queue queries)
+CREATE INDEX IF NOT EXISTS idx_decisions_agent_status ON decisions(agent_id, status);
+
+-- Partial index for unresolved escalations (active escalations dashboard)
+CREATE INDEX IF NOT EXISTS idx_escalations_unresolved ON escalations(resolved_at) WHERE resolved_at IS NULL;
+
+-- Index for messages by thread with time-based sorting (chat/conversation queries)
+CREATE INDEX IF NOT EXISTS idx_messages_thread_time ON messages(thread_id, created_at DESC);


### PR DESCRIPTION
## Summary
Adds missing database indexes for frequently queried patterns to improve query performance.

## Indexes Added

| Index | Table | Columns | Purpose |
|-------|-------|---------|---------|
| idx_tasks_assigner | tasks | assigner_id | Lookup tasks by assigner |
| idx_activities_agent_time | activities | agent_id, created_at DESC | Activity feed queries with time sorting |
| idx_decisions_agent_status | decisions | agent_id, status | Decision queue filtering |
| idx_escalations_unresolved | escalations | resolved_at (partial) | Active escalations dashboard |
| idx_messages_thread_time | messages | thread_id, created_at DESC | Chat/conversation message retrieval |

## Migration Verification
```
$ supabase db push --dry-run
Would push these migrations:
 • 021_add_performance_indexes.sql
```

## Checklist
- [x] Migration follows naming convention (021_add_performance_indexes.sql)
- [x] Uses IF NOT EXISTS for idempotency
- [x] Verified with dry-run push
- [x] Includes comments explaining purpose

Closes #79