### PR TITLE
feat(db): Add query timeout configuration (#89)

### DIFF
--- a/supabase/migrations/022_add_query_timeouts.sql
+++ b/supabase/migrations/022_add_query_timeouts.sql
@@ -1,0 +1,12 @@
+-- Migration: Add query timeout configuration
+-- Issue: #89
+-- 
+-- Set statement timeout at database level (30 seconds)
+ALTER DATABASE current SET statement_timeout = '30s';
+
+-- Set per-role timeouts
+-- Authenticated users (API requests): 15s - fail fast for user-facing queries
+ALTER ROLE authenticated SET statement_timeout = '15s';
+
+-- Service role (background jobs, edge functions): 60s - allow longer for batch operations
+ALTER ROLE service_role SET statement_timeout = '60s';


### PR DESCRIPTION
## Summary
Configures database-level query timeouts to prevent runaway queries.

## Changes
- Set database-level statement timeout to 30s
- Set authenticated role timeout to 15s (fail fast for user-facing queries)
- Set service_role timeout to 60s (allow longer for background jobs/edge functions)

## Testing
- Dry-run passed: `supabase db push --dry-run`

## Migration
- File: `supabase/migrations/022_add_query_timeouts.sql`

Closes #89