### PR TITLE
feat(forms): Add react-hook-form + Zod validation to CreateAgentModal (#83)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -46,6 +47,7 @@
         "react": "19.2.3",
         "react-day-picker": "^9.13.2",
         "react-dom": "19.2.3",
+        "react-hook-form": "^7.71.1",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
@@ -53,7 +55,8 @@
         "swagger-ui-react": "^5.31.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^16.1.6",
@@ -1096,6 +1099,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -12626,6 +12641,22 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-immutable-proptypes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",
@@ -15329,7 +15360,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
@@ -54,6 +55,7 @@
     "react": "19.2.3",
     "react-day-picker": "^9.13.2",
     "react-dom": "19.2.3",
+    "react-hook-form": "^7.71.1",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
@@ -61,7 +63,8 @@
     "swagger-ui-react": "^5.31.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.1.6",

--- a/src/components/dashboard/agents/CreateAgentModal.tsx
+++ b/src/components/dashboard/agents/CreateAgentModal.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
 import { Bot, Sparkles, User, Wrench, Shield, ChevronRight, ChevronLeft, Check } from 'lucide-react';
 import { cn, getInitials, getAvatarColor } from '@/lib/utils';
 import { SUPPORTED_MODELS } from '@/lib/constants/models';
@@ -35,6 +38,15 @@ interface AgentTemplate {
   defaultCapabilities: Capability[];
   suggestedModel: string;
 }
+
+const basicInfoSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or less'),
+  role: z.enum(['ceo', 'manager', 'worker', 'specialist', 'system'] as const),
+  description: z.string().min(1, 'Description is required'),
+  model: z.string().min(1, 'Model is required'),
+});
+
+type BasicInfoFormData = z.infer<typeof basicInfoSchema>;
 
 const templates: AgentTemplate[] = [
   {
@@ -149,8 +161,15 @@ export function CreateAgentModal({ open, onOpenChange, onCreate, loading }: Crea
     switch (step) {
       case 'template':
         return selectedTemplate !== null;
-      case 'basic':
-        return formData.name.trim().length > 0 && formData.description.trim().length > 0;
+      case 'basic': {
+        const result = basicInfoSchema.safeParse({
+          name: formData.name,
+          role: formData.role,
+          description: formData.description,
+          model: formData.model,
+        });
+        return result.success;
+      }
       case 'capabilities':
         return (formData.capabilities?.length || 0) > 0;
       case 'review':
@@ -273,6 +292,20 @@ function BasicInfoStep({
   formData: CreateAgentInput; 
   onChange: (data: CreateAgentInput) => void;
 }) {
+  const {
+    register,
+    formState: { errors },
+  } = useForm<BasicInfoFormData>({
+    resolver: zodResolver(basicInfoSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: formData.name,
+      role: formData.role,
+      description: formData.description,
+      model: formData.model,
+    },
+  });
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -280,9 +313,13 @@ function BasicInfoStep({
         <Input
           id="name"
           placeholder="e.g., Marketing Writer, Lead Qualifier"
-          value={formData.name}
-          onChange={(e) => onChange({ ...formData, name: e.target.value })}
+          {...register('name', {
+            onChange: (e) => onChange({ ...formData, name: e.target.value }),
+          })}
         />
+        {errors.name && (
+          <p className="text-sm text-destructive">{errors.name.message}</p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -295,12 +332,16 @@ function BasicInfoStep({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="ceo">CEO (executive oversight)</SelectItem>
             <SelectItem value="manager">Manager (can spawn agents)</SelectItem>
             <SelectItem value="worker">Worker (handles tasks)</SelectItem>
             <SelectItem value="specialist">Specialist (domain expert)</SelectItem>
             <SelectItem value="system">System (infrastructure)</SelectItem>
           </SelectContent>
         </Select>
+        {errors.role && (
+          <p className="text-sm text-destructive">{errors.role.message}</p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -308,10 +349,14 @@ function BasicInfoStep({
         <Textarea
           id="description"
           placeholder="Describe what this agent does and its responsibilities..."
-          value={formData.description}
-          onChange={(e) => onChange({ ...formData, description: e.target.value })}
           rows={4}
+          {...register('description', {
+            onChange: (e) => onChange({ ...formData, description: e.target.value }),
+          })}
         />
+        {errors.description && (
+          <p className="text-sm text-destructive">{errors.description.message}</p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -331,6 +376,9 @@ function BasicInfoStep({
             ))}
           </SelectContent>
         </Select>
+        {errors.model && (
+          <p className="text-sm text-destructive">{errors.model.message}</p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #83

- Install react-hook-form, @hookform/resolvers, and zod
- Create Zod schema for basic info validation
- Integrate react-hook-form with zodResolver
- Add validation error messages below each form input
- Update canProceed function to use schema.safeParse
- Add CEO role option to role select dropdown